### PR TITLE
Solidity syntax that supports all the example solidity files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*-kompiled

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *-kompiled
+out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,96 @@
+SYNTAX_DIR = solidity-lite-syntax
+EXAMPLES_DIR = $(SYNTAX_DIR)/examples
+SYNTAX_FILE_NAME = solidity-syntax
+SYNTAX_FILE = $(SYNTAX_FILE_NAME).md
+MAIN_MODULE = SOLIDITY
+OUTPUT_DIR = out
+
+UNISWAP_PARAMS = $(EXAMPLES_DIR)/swaps/UniswapV2Swap.sol 2>&1 1>$(OUTPUT_DIR)/uniswap.ast
+SOMETOKEN_PARAMS = $(EXAMPLES_DIR)/tokens/SomeToken.sol 2>&1 1>$(OUTPUT_DIR)/sometoken.ast
+SOMEMULTITOKEN_PARAMS = $(EXAMPLES_DIR)/tokens/SomeMultiToken.sol 2>&1 1>$(OUTPUT_DIR)/somemultitoken.ast
+LIQUIDSTAKING_PARAMS = $(EXAMPLES_DIR)/staking/LiquidStaking.sol 2>&1 1>$(OUTPUT_DIR)/liquidstaking.ast
+LIDO_PARAMS = $(EXAMPLES_DIR)/staking/LidoStaking.sol 2>&1 1>$(OUTPUT_DIR)/lidostaking.ast
+LENDINGPOOL_PARAMS = $(EXAMPLES_DIR)/lending/LendingPool.sol 2>&1 1>$(OUTPUT_DIR)/lendingpool.ast
+AAVE_PARAMS = $(EXAMPLES_DIR)/lending/AaveLendingPool.sol 2>&1 1>$(OUTPUT_DIR)/aave.ast
+
+build: $(SYNTAX_DIR)/$(SYNTAX_FILE)
+	kompile $(SYNTAX_DIR)/$(SYNTAX_FILE) --main-module $(MAIN_MODULE) 
+
+build-bison: $(SYNTAX_DIR)/$(SYNTAX_FILE)
+	kompile $(SYNTAX_DIR)/$(SYNTAX_FILE) --main-module $(MAIN_MODULE) --gen-glr-bison-parser
+
+clean:
+	rm -Rf $(SYNTAX_FILE_NAME)-kompiled
+	rm -Rf $(OUTPUT_DIR)
+
+test: test-swap test-tokens test-staking test-lending
+
+test-tokens: test-erc20 test-erc1155
+
+test-staking: test-liquid test-lido
+
+test-lending: test-lendingpool test-aave
+
+test-swap: 
+	mkdir -p $(OUTPUT_DIR)
+	kast $(UNISWAP_PARAMS)
+
+test-erc20: 
+	mkdir -p $(OUTPUT_DIR)
+	kast $(SOMETOKEN_PARAMS)
+
+test-erc1155: 
+	mkdir -p $(OUTPUT_DIR)
+	kast $(SOMEMULTITOKEN_PARAMS)
+
+test-liquid: 
+	mkdir -p $(OUTPUT_DIR)
+	kast $(LIQUIDSTAKING_PARAMS)
+
+test-lido: 
+	mkdir -p $(OUTPUT_DIR)
+	kast $(LIDO_PARAMS)
+
+test-lendingpool: 
+	mkdir -p $(OUTPUT_DIR)
+	kast $(LENDINGPOOL_PARAMS)
+
+test-aave: 
+	mkdir -p $(OUTPUT_DIR)
+	kast $(AAVE_PARAMS)
+
+test-bison: test-bison-swap test-bison-tokens test-bison-staking test-bison-lending
+
+test-bison-tokens: test-bison-erc20 test-bison-erc1155
+
+test-bison-staking: test-bison-liquid test-bison-lido
+
+test-bison-lending: test-bison-lendingpool test-bison-aave
+
+test-bison-swap:
+	mkdir -p $(OUTPUT_DIR)
+	./$(SYNTAX_FILE_NAME)-kompiled/parser_PGM $(UNISWAP_PARAMS)
+
+test-bison-erc20:
+	mkdir -p $(OUTPUT_DIR)
+	./$(SYNTAX_FILE_NAME)-kompiled/parser_PGM $(SOMETOKEN_PARAMS)
+
+test-bison-erc1155:
+	mkdir -p $(OUTPUT_DIR)
+	./$(SYNTAX_FILE_NAME)-kompiled/parser_PGM $(SOMEMULTITOKEN_PARAMS)
+
+test-bison-liquid:
+	mkdir -p $(OUTPUT_DIR)
+	./$(SYNTAX_FILE_NAME)-kompiled/parser_PGM $(LIQUIDSTAKING_PARAMS)
+
+test-bison-lido:
+	mkdir -p $(OUTPUT_DIR)
+	./$(SYNTAX_FILE_NAME)-kompiled/parser_PGM $(LIDO_PARAMS)
+
+test-bison-lendingpool:
+	mkdir -p $(OUTPUT_DIR)
+	./$(SYNTAX_FILE_NAME)-kompiled/parser_PGM $(LENDINGPOOL_PARAMS)
+
+test-bison-aave:
+	mkdir -p $(OUTPUT_DIR)
+	./$(SYNTAX_FILE_NAME)-kompiled/parser_PGM $(AAVE_PARAMS)

--- a/solidity-lite-syntax/examples/lending/AaveLendingPool.sol
+++ b/solidity-lite-syntax/examples/lending/AaveLendingPool.sol
@@ -1,0 +1,1176 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// The source code of this contract uses the following contracts from Aave v1
+// LendingPool: https://github.com/aave/aave-protocol/blob/master/contracts/lendingpool/LendingPool.sol
+// LendingPool Core: https://github.com/aave/aave-protocol/blob/master/contracts/lendingpool/LendingPoolCore.sol
+// LendingPool Core Library: https://github.com/aave/aave-protocol/blob/master/contracts/libraries/CoreLibrary.sol
+// LendingPool Data Provider: https://github.com/aave/aave-protocol/blob/master/contracts/lendingpool/LendingPoolDataProvider.sol
+
+interface IERC20 {
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(
+        address from,
+        address to,
+        uint value
+    ) external returns (bool);
+    function balanceOf(address account) external returns (uint256);
+    function decimals() external returns (uint8);
+}
+
+interface ILendingPoolAddressesProvider {
+    function getPriceOracle() external returns (address);
+    function getLendingRateOracle() external returns (address);
+    function getTokenDistributor() external returns (address);
+}
+
+interface AToken {
+    function balanceOf(address) external returns (uint256);
+    function mintOnDeposit(address, uint256) external;
+}
+
+interface ILendingRateOracle {
+    function getMarketBorrowRate(address) external returns (uint256);
+}
+
+interface IPriceOracleGetter {
+    function getAssetPrice(address _asset) external returns (uint256);
+}
+
+interface IReserveInterestRateStrategy {
+    function getBaseVariableBorrowRate() external returns (uint256);
+    function calculateInterestRates(
+        address _reserve,
+        uint256 _utilizationRate,
+        uint256 _totalBorrowsStable,
+        uint256 _totalBorrowsVariable,
+        uint256 _averageStableBorrowRate
+    ) external returns (uint256[] memory return_data);
+}
+
+contract AaveLendingPool {
+    enum InterestRateMode {
+        NONE,
+        STABLE,
+        VARIABLE
+    }
+
+    struct BorrowLocalVars {
+        uint256 currentLtv;
+        uint256 currentLiquidationThreshold;
+        uint256 borrowFee;
+        uint256 amountOfCollateralNeededETH;
+        uint256 userCollateralBalanceETH;
+        uint256 userBorrowBalanceETH;
+        uint256 userTotalFeesETH;
+        uint256 borrowBalanceIncrease;
+        uint256 availableLiquidity;
+        uint256 finalUserBorrowRate;
+        InterestRateMode rateMode;
+        bool healthFactorBelowThreshold;
+    }
+
+    struct RepayLocalVars {
+        uint256 principalBorrowBalance;
+        uint256 compoundedBorrowBalance;
+        uint256 borrowBalanceIncrease;
+        bool isETH;
+        uint256 paybackAmount;
+        uint256 paybackAmountMinusFees;
+        uint256 originationFee;
+    }
+
+    struct ReserveData {
+        uint256 lastLiquidityCumulativeIndex;
+        uint256 currentLiquidityRate;
+        uint256 totalBorrowsStable;
+        uint256 totalBorrowsVariable;
+        uint256 currentVariableBorrowRate;
+        uint256 currentStableBorrowRate;
+        uint256 currentAverageStableBorrowRate;
+        uint256 lastVariableBorrowCumulativeIndex;
+        uint256 baseLTVasCollateral;
+        uint256 liquidationThreshold;
+        uint256 decimals;
+        address aTokenAddress;
+        address interestRateStrategyAddress;
+        uint40 lastUpdateTimestamp;
+        bool borrowingEnabled;
+        bool usageAsCollateralEnabled;
+        bool isStableBorrowRateEnabled;
+    }
+
+    struct UserReserveData {
+        uint256 principalBorrowBalance;
+        uint256 lastVariableBorrowCumulativeIndex;
+        uint256 originationFee;
+        uint256 stableBorrowRate;
+        uint40 lastUpdateTimestamp;
+        bool useAsCollateral;
+    }
+
+    struct UserGlobalDataLocalVars {
+        uint256 reserveUnitPrice;
+        uint256 tokenUnit;
+        uint256 compoundedLiquidityBalance;
+        uint256 compoundedBorrowBalance;
+        uint256 reserveDecimals;
+        uint256 baseLtv;
+        uint256 liquidationThreshold;
+        uint256 originationFee;
+        bool usageAsCollateralEnabled;
+        bool userUsesReserveAsCollateral;
+        address currentReserve;
+    }
+
+    struct BalanceDecreaseAllowedLocalVars {
+        uint256 decimals;
+        uint256 collateralBalanceETH;
+        uint256 borrowBalanceETH;
+        uint256 totalFeesETH;
+        uint256 currentLiquidationThreshold;
+        uint256 reserveLiquidationThreshold;
+        uint256 amountToDecreaseETH;
+        uint256 collateralBalancefterDecrease;
+        uint256 liquidationThresholdAfterDecrease;
+        bool reserveUsageAsCollateralEnabled;
+    }
+
+    ILendingPoolAddressesProvider public addressesProvider;
+
+    /* LendingPoolCore variables*/
+    mapping(address => ReserveData) internal reserves;
+    mapping(address => mapping(address => UserReserveData))
+        internal usersReserveData;
+    address[] public reservesList;
+
+    constructor(address _addressesProvider) {
+        addressesProvider = ILendingPoolAddressesProvider(_addressesProvider);
+    }
+
+    function deposit(address _reserve, uint256 _amount) external {
+        AToken aToken = AToken(core_getReserveATokenAddress(_reserve));
+        bool isFirstDeposit = aToken.balanceOf(msg.sender) == 0;
+        core_updateStateOnDeposit(
+            _reserve,
+            msg.sender,
+            _amount,
+            isFirstDeposit
+        );
+        aToken.mintOnDeposit(msg.sender, _amount);
+        IERC20(_reserve).transferFrom(msg.sender, address(this), _amount);
+    }
+
+    function redeemUnderlying(
+        address _reserve,
+        address _user,
+        uint256 _amount,
+        uint256 _aTokenBalanceAfterRedeem
+    ) external {
+        uint256 currentAvailableLiquidity = IERC20(_reserve).balanceOf(
+            address(this)
+        );
+        require(
+            currentAvailableLiquidity >= _amount,
+            "There is not enough liquidity available to redeem"
+        );
+        core_updateStateOnRedeem(
+            _reserve,
+            _user,
+            _amount,
+            _aTokenBalanceAfterRedeem == 0
+        );
+        IERC20(_reserve).transfer(_user, _amount);
+    }
+
+    function borrow(
+        address _reserve,
+        uint256 _amount,
+        uint256 _interestRateMode
+    ) external {
+        BorrowLocalVars memory vars;
+
+        require(
+            core_isReserveBorrowingEnabled(_reserve),
+            "Reserve is not enabled for borrowing"
+        );
+
+        require(
+            uint256(InterestRateMode.VARIABLE) == _interestRateMode ||
+                uint256(InterestRateMode.STABLE) == _interestRateMode,
+            "Invalid interest rate mode selected"
+        );
+
+        vars.rateMode = InterestRateMode(_interestRateMode);
+
+        vars.availableLiquidity = IERC20(_reserve).balanceOf(address(this));
+
+        require(
+            vars.availableLiquidity >= _amount,
+            "There is not enough liquidity available in the reserve"
+        );
+
+        uint256[] memory return_data = dataProvider_calculateUserGlobalData(
+            msg.sender
+        );
+        vars.userCollateralBalanceETH = return_data[1];
+        vars.userBorrowBalanceETH = return_data[2];
+        vars.userTotalFeesETH = return_data[3];
+        vars.currentLtv = return_data[4];
+        vars.currentLiquidationThreshold = return_data[5];
+
+        require(
+            vars.userCollateralBalanceETH > 0,
+            "The collateral balance is 0"
+        );
+
+        vars.borrowFee = 0;
+
+        vars
+            .amountOfCollateralNeededETH = dataProvider_calculateCollateralNeededInETH(
+            _reserve,
+            _amount,
+            vars.borrowFee,
+            vars.userBorrowBalanceETH,
+            vars.userTotalFeesETH,
+            vars.currentLtv
+        );
+
+        require(
+            vars.amountOfCollateralNeededETH <= vars.userCollateralBalanceETH,
+            "There is not enough collateral to cover a new borrow"
+        );
+
+        if (vars.rateMode == InterestRateMode.STABLE) {
+            require(
+                core_isUserAllowedToBorrowAtStable(
+                    _reserve,
+                    msg.sender,
+                    _amount
+                ),
+                "User cannot borrow the selected amount with a stable rate"
+            );
+
+            uint256 maxLoanPercent = 25;
+            uint256 maxLoanSizeStable = (vars.availableLiquidity *
+                maxLoanPercent) / 100;
+
+            require(
+                _amount <= maxLoanSizeStable,
+                "User is trying to borrow too much liquidity at a stable rate"
+            );
+        }
+
+        uint256[] memory update_return_data = core_updateStateOnBorrow(
+            _reserve,
+            msg.sender,
+            _amount,
+            vars.borrowFee,
+            vars.rateMode
+        );
+
+        vars.finalUserBorrowRate = update_return_data[0];
+        vars.borrowBalanceIncrease = update_return_data[1];
+
+        IERC20(_reserve).transfer(msg.sender, _amount);
+    }
+
+    function repay(
+        address _reserve,
+        uint256 _amount,
+        address _onBehalfOf
+    ) external {
+        RepayLocalVars memory vars;
+        uint256[] memory return_data = core_getUserBorrowBalances(
+            _reserve,
+            _onBehalfOf
+        );
+
+        vars.principalBorrowBalance = return_data[0];
+        vars.compoundedBorrowBalance = return_data[1];
+        vars.borrowBalanceIncrease = return_data[2];
+
+        vars.originationFee = core_getUserOriginationFee(_reserve, _onBehalfOf);
+
+        require(
+            vars.compoundedBorrowBalance > 0,
+            "The user does not have any borrow pending"
+        );
+
+        require(
+            _amount != type(uint256).max || msg.sender == _onBehalfOf,
+            "To repay on behalf of an user an explicit amount to repay is needed."
+        );
+
+        vars.paybackAmount = vars.compoundedBorrowBalance + vars.originationFee;
+
+        if (_amount != type(uint256).max && _amount < vars.paybackAmount) {
+            vars.paybackAmount = _amount;
+        }
+
+        if (vars.paybackAmount <= vars.originationFee) {
+            core_updateStateOnRepay(
+                _reserve,
+                _onBehalfOf,
+                0,
+                vars.paybackAmount,
+                vars.borrowBalanceIncrease,
+                false
+            );
+
+            IERC20(_reserve).transferFrom(
+                _onBehalfOf,
+                address(uint160(addressesProvider.getTokenDistributor())),
+                vars.paybackAmount
+            );
+
+            return;
+        }
+
+        vars.paybackAmountMinusFees = vars.paybackAmount - vars.originationFee;
+
+        core_updateStateOnRepay(
+            _reserve,
+            _onBehalfOf,
+            vars.paybackAmountMinusFees,
+            vars.originationFee,
+            vars.borrowBalanceIncrease,
+            vars.compoundedBorrowBalance == vars.paybackAmountMinusFees
+        );
+
+        if (vars.originationFee > 0) {
+            IERC20(_reserve).transferFrom(
+                msg.sender,
+                address(uint160(addressesProvider.getTokenDistributor())),
+                vars.originationFee
+            );
+        }
+
+        IERC20(_reserve).transferFrom(
+            msg.sender,
+            address(this),
+            vars.paybackAmountMinusFees
+        );
+    }
+
+    /* LendingPoolCore functions*/
+
+    function core_addReserve(
+        address _reserve,
+        ReserveData memory _reserve_data
+    ) public {
+        reserves[_reserve] = _reserve_data;
+        reservesList.push(_reserve);
+    }
+
+    function core_addUserReserveData(
+        address _user,
+        address _reserve,
+        UserReserveData memory _user_reserve_data
+    ) public {
+        usersReserveData[_user][_reserve] = _user_reserve_data;
+    }
+
+    function core_getReserveATokenAddress(
+        address _reserve
+    ) public returns (address) {
+        ReserveData storage reserve = reserves[_reserve];
+        return reserve.aTokenAddress;
+    }
+
+    function core_updateStateOnDeposit(
+        address _reserve,
+        address _user,
+        uint256 _amount,
+        bool _isFirstDeposit
+    ) internal {
+        core_updateCumulativeIndexes(reserves[_reserve]);
+        core_updateReserveInterestRatesAndTimestampInternal(
+            _reserve,
+            _amount,
+            0
+        );
+
+        if (_isFirstDeposit) {
+            core_setUserUseReserveAsCollateral(_reserve, _user, true);
+        }
+    }
+
+    function core_updateStateOnRedeem(
+        address _reserve,
+        address _user,
+        uint256 _amountRedeemed,
+        bool _userRedeemedEverything
+    ) internal {
+        core_updateCumulativeIndexes(reserves[_reserve]);
+        core_updateReserveInterestRatesAndTimestampInternal(
+            _reserve,
+            0,
+            _amountRedeemed
+        );
+
+        if (_userRedeemedEverything) {
+            core_setUserUseReserveAsCollateral(_reserve, _user, false);
+        }
+    }
+
+    function core_isReserveBorrowingEnabled(
+        address _reserve
+    ) internal returns (bool) {
+        ReserveData storage reserve = reserves[_reserve];
+        return reserve.borrowingEnabled;
+    }
+
+    function core_isUserAllowedToBorrowAtStable(
+        address _reserve,
+        address _user,
+        uint256 _amount
+    ) internal returns (bool) {
+        ReserveData storage reserve = reserves[_reserve];
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+
+        if (!reserve.isStableBorrowRateEnabled) return false;
+
+        return
+            !user.useAsCollateral ||
+            !reserve.usageAsCollateralEnabled ||
+            _amount > core_getUserUnderlyingAssetBalance(_reserve, _user);
+    }
+
+    function core_updateStateOnBorrow(
+        address _reserve,
+        address _user,
+        uint256 _amountBorrowed,
+        uint256 _borrowFee,
+        InterestRateMode _rateMode
+    ) internal returns (uint256[] memory return_data) {
+        return_data = new uint256[](2);
+
+        uint256[]
+            memory borrow_balance_return_data = core_getUserBorrowBalances(
+                _reserve,
+                _user
+            );
+        uint256 principalBorrowBalance = borrow_balance_return_data[0];
+        uint256 balanceIncrease = borrow_balance_return_data[2];
+
+        core_updateReserveStateOnBorrowInternal(
+            _reserve,
+            _user,
+            principalBorrowBalance,
+            balanceIncrease,
+            _amountBorrowed,
+            _rateMode
+        );
+
+        core_updateUserStateOnBorrowInternal(
+            _reserve,
+            _user,
+            _amountBorrowed,
+            balanceIncrease,
+            _borrowFee,
+            _rateMode
+        );
+
+        core_updateReserveInterestRatesAndTimestampInternal(
+            _reserve,
+            0,
+            _amountBorrowed
+        );
+
+        return_data[0] = core_getUserCurrentBorrowRate(_reserve, _user);
+        return_data[1] = balanceIncrease;
+    }
+
+    function core_getUserOriginationFee(
+        address _reserve,
+        address _user
+    ) internal returns (uint256) {
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+        return user.originationFee;
+    }
+
+    function core_updateStateOnRepay(
+        address _reserve,
+        address _user,
+        uint256 _paybackAmountMinusFees,
+        uint256 _originationFeeRepaid,
+        uint256 _balanceIncrease,
+        bool _repaidWholeLoan
+    ) internal {
+        core_updateReserveStateOnRepayInternal(
+            _reserve,
+            _user,
+            _paybackAmountMinusFees,
+            _balanceIncrease
+        );
+        core_updateUserStateOnRepayInternal(
+            _reserve,
+            _user,
+            _paybackAmountMinusFees,
+            _originationFeeRepaid,
+            _balanceIncrease,
+            _repaidWholeLoan
+        );
+
+        core_updateReserveInterestRatesAndTimestampInternal(
+            _reserve,
+            _paybackAmountMinusFees,
+            0
+        );
+    }
+
+    function core_getUserBorrowBalances(
+        address _reserve,
+        address _user
+    ) public returns (uint256[] memory return_data) {
+        return_data = new uint256[](3);
+
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+        if (user.principalBorrowBalance == 0) {
+            return return_data;
+        }
+
+        uint256 principal = user.principalBorrowBalance;
+        uint256 compoundedBalance = core_getCompoundedBorrowBalance(
+            user,
+            reserves[_reserve]
+        );
+        return_data[0] = principal;
+        return_data[1] = compoundedBalance;
+        return_data[2] = compoundedBalance - principal;
+    }
+
+    function core_getUserCurrentBorrowRateMode(
+        address _reserve,
+        address _user
+    ) public returns (InterestRateMode) {
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+
+        if (user.principalBorrowBalance == 0) {
+            return InterestRateMode.NONE;
+        }
+
+        return
+            user.stableBorrowRate > 0
+                ? InterestRateMode.STABLE
+                : InterestRateMode.VARIABLE;
+    }
+
+    function core_getUserUnderlyingAssetBalance(
+        address _reserve,
+        address _user
+    ) public returns (uint256) {
+        AToken aToken = AToken(reserves[_reserve].aTokenAddress);
+        return aToken.balanceOf(_user);
+    }
+
+    function core_setUserUseReserveAsCollateral(
+        address _reserve,
+        address _user,
+        bool _useAsCollateral
+    ) public {
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+        user.useAsCollateral = _useAsCollateral;
+    }
+
+    function core_updateReserveInterestRatesAndTimestampInternal(
+        address _reserve,
+        uint256 _liquidityAdded,
+        uint256 _liquidityTaken
+    ) internal {
+        ReserveData storage reserve = reserves[_reserve];
+        uint256[] memory return_data = IReserveInterestRateStrategy(
+            reserve.interestRateStrategyAddress
+        ).calculateInterestRates(
+                _reserve,
+                IERC20(_reserve).balanceOf(address(this)) +
+                    _liquidityAdded -
+                    _liquidityTaken,
+                reserve.totalBorrowsStable,
+                reserve.totalBorrowsVariable,
+                reserve.currentAverageStableBorrowRate
+            );
+
+        uint256 newLiquidityRate = return_data[0];
+        uint256 newStableRate = return_data[1];
+        uint256 newVariableRate = return_data[2];
+
+        reserve.currentLiquidityRate = newLiquidityRate;
+        reserve.currentStableBorrowRate = newStableRate;
+        reserve.currentVariableBorrowRate = newVariableRate;
+
+        reserve.lastUpdateTimestamp = uint40(block.timestamp);
+    }
+
+    function core_updateCumulativeIndexes(ReserveData storage _self) internal {
+        uint256 totalBorrows = _self.totalBorrowsStable +
+            _self.totalBorrowsVariable;
+
+        if (totalBorrows > 0) {
+            uint256 cumulatedLiquidityInterest = core_calculateLinearInterest_mocked(
+                    _self.currentLiquidityRate,
+                    _self.lastUpdateTimestamp
+                );
+
+            _self.lastLiquidityCumulativeIndex =
+                (cumulatedLiquidityInterest / 1e27) *
+                _self.lastLiquidityCumulativeIndex;
+
+            uint256 cumulatedVariableBorrowInterest = core_calculateCompoundedInterest_mocked(
+                    _self.currentVariableBorrowRate,
+                    _self.lastUpdateTimestamp
+                );
+            _self.lastVariableBorrowCumulativeIndex =
+                (cumulatedVariableBorrowInterest / 1e27) *
+                _self.lastVariableBorrowCumulativeIndex;
+        }
+    }
+
+    function core_updateReserveStateOnBorrowInternal(
+        address _reserve,
+        address _user,
+        uint256 _principalBorrowBalance,
+        uint256 _balanceIncrease,
+        uint256 _amountBorrowed,
+        InterestRateMode _rateMode
+    ) internal {
+        core_updateCumulativeIndexes(reserves[_reserve]);
+
+        core_updateReserveTotalBorrowsByRateModeInternal(
+            _reserve,
+            _user,
+            _principalBorrowBalance,
+            _balanceIncrease,
+            _amountBorrowed,
+            _rateMode
+        );
+    }
+
+    function core_updateUserStateOnBorrowInternal(
+        address _reserve,
+        address _user,
+        uint256 _amountBorrowed,
+        uint256 _balanceIncrease,
+        uint256 _fee,
+        InterestRateMode _rateMode
+    ) internal {
+        ReserveData storage reserve = reserves[_reserve];
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+
+        if (_rateMode == InterestRateMode.STABLE) {
+            user.stableBorrowRate = reserve.currentStableBorrowRate;
+            user.lastVariableBorrowCumulativeIndex = 0;
+        } else if (_rateMode == InterestRateMode.VARIABLE) {
+            user.stableBorrowRate = 0;
+            user.lastVariableBorrowCumulativeIndex = reserve
+                .lastVariableBorrowCumulativeIndex;
+        } else {
+            revert("Invalid borrow rate mode");
+        }
+        user.principalBorrowBalance =
+            user.principalBorrowBalance +
+            _amountBorrowed +
+            _balanceIncrease;
+        user.originationFee = user.originationFee + _fee;
+
+        user.lastUpdateTimestamp = uint40(block.timestamp);
+    }
+
+    function core_getUserCurrentBorrowRate(
+        address _reserve,
+        address _user
+    ) internal returns (uint256) {
+        InterestRateMode rateMode = core_getUserCurrentBorrowRateMode(
+            _reserve,
+            _user
+        );
+
+        if (rateMode == InterestRateMode.NONE) {
+            return 0;
+        }
+
+        return
+            rateMode == InterestRateMode.STABLE
+                ? usersReserveData[_user][_reserve].stableBorrowRate
+                : reserves[_reserve].currentVariableBorrowRate;
+    }
+
+    function core_updateReserveStateOnRepayInternal(
+        address _reserve,
+        address _user,
+        uint256 _paybackAmountMinusFees,
+        uint256 _balanceIncrease
+    ) internal {
+        ReserveData storage reserve = reserves[_reserve];
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+
+        InterestRateMode borrowRateMode = core_getUserCurrentBorrowRateMode(
+            _reserve,
+            _user
+        );
+
+        core_updateCumulativeIndexes(reserves[_reserve]);
+
+        if (borrowRateMode == InterestRateMode.STABLE) {
+            core_increaseTotalBorrowsStableAndUpdateAverageRate(
+                reserve,
+                _balanceIncrease,
+                user.stableBorrowRate
+            );
+            core_decreaseTotalBorrowsStableAndUpdateAverageRate(
+                reserve,
+                _paybackAmountMinusFees,
+                user.stableBorrowRate
+            );
+        } else {
+            core_increaseTotalBorrowsVariable(reserve, _balanceIncrease);
+            core_decreaseTotalBorrowsVariable(reserve, _paybackAmountMinusFees);
+        }
+    }
+
+    function core_updateUserStateOnRepayInternal(
+        address _reserve,
+        address _user,
+        uint256 _paybackAmountMinusFees,
+        uint256 _originationFeeRepaid,
+        uint256 _balanceIncrease,
+        bool _repaidWholeLoan
+    ) internal {
+        ReserveData storage reserve = reserves[_reserve];
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+
+        user.principalBorrowBalance =
+            user.principalBorrowBalance +
+            _balanceIncrease -
+            _paybackAmountMinusFees;
+        user.lastVariableBorrowCumulativeIndex = reserve
+            .lastVariableBorrowCumulativeIndex;
+
+        if (_repaidWholeLoan) {
+            user.stableBorrowRate = 0;
+            user.lastVariableBorrowCumulativeIndex = 0;
+        }
+        user.originationFee = user.originationFee - _originationFeeRepaid;
+
+        user.lastUpdateTimestamp = uint40(block.timestamp);
+    }
+
+    function core_increaseTotalBorrowsStableAndUpdateAverageRate(
+        ReserveData storage _reserve,
+        uint256 _amount,
+        uint256 _rate
+    ) internal {
+        uint256 previousTotalBorrowStable = _reserve.totalBorrowsStable;
+        _reserve.totalBorrowsStable = _reserve.totalBorrowsStable + _amount;
+
+        uint256 weightedLastBorrow = _amount * 1e9 * _rate;
+        uint256 weightedPreviousTotalBorrows = previousTotalBorrowStable *
+            1e9 *
+            _reserve.currentAverageStableBorrowRate;
+
+        _reserve.currentAverageStableBorrowRate =
+            (weightedLastBorrow + weightedPreviousTotalBorrows) /
+            (_reserve.totalBorrowsStable * 1e9);
+    }
+
+    function core_decreaseTotalBorrowsStableAndUpdateAverageRate(
+        ReserveData storage _reserve,
+        uint256 _amount,
+        uint256 _rate
+    ) internal {
+        require(
+            _reserve.totalBorrowsStable >= _amount,
+            "Invalid amount to decrease"
+        );
+
+        uint256 previousTotalBorrowStable = _reserve.totalBorrowsStable;
+
+        _reserve.totalBorrowsStable = _reserve.totalBorrowsStable - _amount;
+
+        if (_reserve.totalBorrowsStable == 0) {
+            _reserve.currentAverageStableBorrowRate = 0;
+            return;
+        }
+
+        uint256 weightedLastBorrow = _amount * 1e9 * _rate;
+        uint256 weightedPreviousTotalBorrows = previousTotalBorrowStable *
+            1e9 *
+            _reserve.currentAverageStableBorrowRate;
+
+        require(
+            weightedPreviousTotalBorrows >= weightedLastBorrow,
+            "The amounts to subtract don't match"
+        );
+
+        _reserve.currentAverageStableBorrowRate =
+            (weightedPreviousTotalBorrows - weightedLastBorrow) /
+            (_reserve.totalBorrowsStable * 1e9);
+    }
+
+    function core_increaseTotalBorrowsVariable(
+        ReserveData storage _reserve,
+        uint256 _amount
+    ) internal {
+        _reserve.totalBorrowsVariable = _reserve.totalBorrowsVariable + _amount;
+    }
+
+    function core_decreaseTotalBorrowsVariable(
+        ReserveData storage _reserve,
+        uint256 _amount
+    ) internal {
+        require(
+            _reserve.totalBorrowsVariable >= _amount,
+            "The amount that is being subtracted from the variable total borrows is incorrect"
+        );
+        _reserve.totalBorrowsVariable = _reserve.totalBorrowsVariable - _amount;
+    }
+
+    function core_getCompoundedBorrowBalance(
+        UserReserveData storage _self,
+        ReserveData storage _reserve
+    ) internal returns (uint256) {
+        if (_self.principalBorrowBalance == 0) return 0;
+
+        uint256 principalBorrowBalanceRay = _self.principalBorrowBalance * 1e9;
+        uint256 compoundedBalance = 0;
+        uint256 cumulatedInterest = 0;
+
+        if (_self.stableBorrowRate > 0) {
+            cumulatedInterest = core_calculateCompoundedInterest_mocked(
+                _self.stableBorrowRate,
+                _self.lastUpdateTimestamp
+            );
+        } else {
+            cumulatedInterest =
+                (core_calculateCompoundedInterest_mocked(
+                    _reserve.currentVariableBorrowRate,
+                    _reserve.lastUpdateTimestamp
+                ) * _reserve.lastVariableBorrowCumulativeIndex) /
+                _self.lastVariableBorrowCumulativeIndex;
+        }
+
+        compoundedBalance =
+            (principalBorrowBalanceRay * cumulatedInterest) /
+            1e9;
+
+        if (compoundedBalance == _self.principalBorrowBalance) {
+            if (_self.lastUpdateTimestamp != block.timestamp) {
+                return _self.principalBorrowBalance + 1 wei;
+            }
+        }
+
+        return compoundedBalance;
+    }
+
+    function core_calculateLinearInterest_mocked(
+        uint256 /*_rate*/,
+        uint40 /*_lastUpdateTimestamp*/
+    ) internal returns (uint256) {
+        return 1e27 + 0.01 * 1e27;
+    }
+
+    function core_calculateCompoundedInterest_mocked(
+        uint256 /*_rate*/,
+        uint40 /*_lastUpdateTimestamp*/
+    ) internal returns (uint256) {
+        return 1e27 + 0.01 * 1e27;
+    }
+
+    function core_updateReserveTotalBorrowsByRateModeInternal(
+        address _reserve,
+        address _user,
+        uint256 _principalBalance,
+        uint256 _balanceIncrease,
+        uint256 _amountBorrowed,
+        InterestRateMode _newBorrowRateMode
+    ) internal {
+        InterestRateMode previousRateMode = core_getUserCurrentBorrowRateMode(
+            _reserve,
+            _user
+        );
+        ReserveData storage reserve = reserves[_reserve];
+
+        if (previousRateMode == InterestRateMode.STABLE) {
+            UserReserveData storage user = usersReserveData[_user][_reserve];
+            core_decreaseTotalBorrowsStableAndUpdateAverageRate(
+                reserve,
+                _principalBalance,
+                user.stableBorrowRate
+            );
+        } else if (previousRateMode == InterestRateMode.VARIABLE) {
+            core_decreaseTotalBorrowsVariable(reserve, _principalBalance);
+        }
+
+        uint256 newPrincipalAmount = _principalBalance +
+            _balanceIncrease +
+            _amountBorrowed;
+        if (_newBorrowRateMode == InterestRateMode.STABLE) {
+            core_increaseTotalBorrowsStableAndUpdateAverageRate(
+                reserve,
+                newPrincipalAmount,
+                reserve.currentStableBorrowRate
+            );
+        } else if (_newBorrowRateMode == InterestRateMode.VARIABLE) {
+            core_increaseTotalBorrowsVariable(reserve, newPrincipalAmount);
+        } else {
+            revert("Invalid new borrow rate mode");
+        }
+    }
+
+    function core_getUserBasicReserveData(
+        address _reserve,
+        address _user
+    ) internal returns (uint256[] memory return_data) {
+        return_data = new uint256[](4);
+        ReserveData storage reserve = reserves[_reserve];
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+
+        uint256 underlyingBalance = core_getUserUnderlyingAssetBalance(
+            _reserve,
+            _user
+        );
+
+        if (user.principalBorrowBalance == 0) {
+            return_data[0] = underlyingBalance;
+            return_data[3] = user.useAsCollateral ? 1 : 0;
+            return return_data;
+        }
+
+        return_data[0] = underlyingBalance;
+        return_data[1] = core_getCompoundedBorrowBalance(user, reserve);
+        return_data[2] = user.originationFee;
+        return_data[3] = user.useAsCollateral ? 1 : 0;
+    }
+
+    function core_getReserveConfiguration(
+        address _reserve
+    ) internal returns (uint256[] memory return_data) {
+        return_data = new uint256[](4);
+
+        uint256 decimals;
+        uint256 baseLTVasCollateral;
+        uint256 liquidationThreshold;
+        bool usageAsCollateralEnabled;
+
+        ReserveData storage reserve = reserves[_reserve];
+        decimals = reserve.decimals;
+        baseLTVasCollateral = reserve.baseLTVasCollateral;
+        liquidationThreshold = reserve.liquidationThreshold;
+        usageAsCollateralEnabled = reserve.usageAsCollateralEnabled;
+
+        return_data[0] = decimals;
+        return_data[1] = baseLTVasCollateral;
+        return_data[2] = liquidationThreshold;
+        return_data[3] = usageAsCollateralEnabled ? 1 : 0;
+    }
+
+    function core_isUserUseReserveAsCollateralEnabled(
+        address _reserve,
+        address _user
+    ) internal returns (bool) {
+        UserReserveData storage user = usersReserveData[_user][_reserve];
+        return user.useAsCollateral;
+    }
+
+    /* LendingPoolDataProvider functions*/
+    function dataProvider_calculateUserGlobalData(
+        address _user
+    ) public returns (uint256[] memory return_data) {
+        return_data = new uint256[](7);
+
+        IPriceOracleGetter oracle = IPriceOracleGetter(
+            addressesProvider.getPriceOracle()
+        );
+
+        UserGlobalDataLocalVars memory vars;
+
+        uint256[] memory reserve_data_return;
+        uint256[] memory reserve_conf_return;
+
+        for (uint256 i = 0; i < reservesList.length; i++) {
+            vars.currentReserve = reservesList[i];
+            reserve_data_return = core_getUserBasicReserveData(
+                vars.currentReserve,
+                _user
+            );
+
+            vars.compoundedLiquidityBalance = reserve_data_return[0];
+            vars.compoundedBorrowBalance = reserve_data_return[1];
+            vars.originationFee = reserve_data_return[2];
+            vars.userUsesReserveAsCollateral = reserve_data_return[3] == 1
+                ? true
+                : false;
+
+            if (
+                vars.compoundedLiquidityBalance == 0 &&
+                vars.compoundedBorrowBalance == 0
+            ) {
+                continue;
+            }
+
+            reserve_conf_return = core_getReserveConfiguration(
+                vars.currentReserve
+            );
+
+            vars.reserveDecimals = reserve_conf_return[0];
+            vars.baseLtv = reserve_conf_return[1];
+            vars.liquidationThreshold = reserve_conf_return[2];
+            vars.usageAsCollateralEnabled = reserve_conf_return[3] == 1
+                ? true
+                : false;
+
+            vars.tokenUnit = 10 ** vars.reserveDecimals;
+            vars.reserveUnitPrice = oracle.getAssetPrice(vars.currentReserve);
+
+            if (vars.compoundedLiquidityBalance > 0) {
+                uint256 liquidityBalanceETH = (vars.reserveUnitPrice *
+                    vars.compoundedLiquidityBalance) / vars.tokenUnit;
+                return_data[0] = return_data[0] + liquidityBalanceETH;
+
+                if (
+                    vars.usageAsCollateralEnabled &&
+                    vars.userUsesReserveAsCollateral
+                ) {
+                    return_data[1] = return_data[1] + liquidityBalanceETH;
+                    return_data[4] =
+                        return_data[4] +
+                        (liquidityBalanceETH * vars.baseLtv);
+                    return_data[5] =
+                        return_data[5] +
+                        (liquidityBalanceETH * vars.liquidationThreshold);
+                }
+            }
+
+            if (vars.compoundedBorrowBalance > 0) {
+                return_data[2] =
+                    return_data[2] +
+                    ((vars.reserveUnitPrice * vars.compoundedBorrowBalance) /
+                        vars.tokenUnit);
+                return_data[3] =
+                    return_data[3] +
+                    ((vars.originationFee * vars.reserveUnitPrice) /
+                        vars.tokenUnit);
+            }
+        }
+
+        return_data[4] = return_data[1] > 0
+            ? return_data[4] / return_data[1]
+            : 0;
+        return_data[5] = return_data[1] > 0
+            ? return_data[5] / return_data[1]
+            : 0;
+
+        return_data[6] = dataProvider_calculateHealthFactorFromBalancesInternal(
+            return_data[1],
+            return_data[2],
+            return_data[3],
+            return_data[5]
+        );
+    }
+
+    function dataProvider_calculateCollateralNeededInETH(
+        address _reserve,
+        uint256 _amount,
+        uint256 _fee,
+        uint256 _userCurrentBorrowBalanceTH,
+        uint256 _userCurrentFeesETH,
+        uint256 _userCurrentLtv
+    ) internal returns (uint256) {
+        uint256 reserveDecimals = IERC20(_reserve).decimals();
+
+        IPriceOracleGetter oracle = IPriceOracleGetter(
+            addressesProvider.getPriceOracle()
+        );
+
+        uint256 requestedBorrowAmountETH = (oracle.getAssetPrice(_reserve) *
+            (_amount + _fee)) / (10 ** reserveDecimals);
+
+        uint256 collateralNeededInETH = ((_userCurrentBorrowBalanceTH +
+            _userCurrentFeesETH +
+            requestedBorrowAmountETH) * 100) / _userCurrentLtv;
+
+        return collateralNeededInETH;
+    }
+
+    function dataProvider_balanceDecreaseAllowed(
+        address _reserve,
+        address _user,
+        uint256 _amount
+    ) internal returns (bool) {
+        BalanceDecreaseAllowedLocalVars memory vars;
+        uint256[] memory reserve_conf_return;
+
+        reserve_conf_return = core_getReserveConfiguration(_reserve);
+
+        vars.decimals = reserve_conf_return[0];
+        vars.reserveLiquidationThreshold = reserve_conf_return[2];
+        vars.reserveUsageAsCollateralEnabled = reserve_conf_return[3] == 1
+            ? true
+            : false;
+
+        if (
+            !vars.reserveUsageAsCollateralEnabled ||
+            !core_isUserUseReserveAsCollateralEnabled(_reserve, _user)
+        ) {
+            return true;
+        }
+
+        uint256[] memory return_data = dataProvider_calculateUserGlobalData(
+            _user
+        );
+        vars.collateralBalanceETH = return_data[1];
+        vars.borrowBalanceETH = return_data[2];
+        vars.totalFeesETH = return_data[3];
+        vars.currentLiquidationThreshold = return_data[5];
+
+        if (vars.borrowBalanceETH == 0) {
+            return true;
+        }
+
+        IPriceOracleGetter oracle = IPriceOracleGetter(
+            addressesProvider.getPriceOracle()
+        );
+
+        vars.amountToDecreaseETH =
+            (oracle.getAssetPrice(_reserve) * _amount) /
+            (10 ** vars.decimals);
+
+        vars.collateralBalancefterDecrease =
+            vars.collateralBalanceETH -
+            vars.amountToDecreaseETH;
+
+        if (vars.collateralBalancefterDecrease == 0) {
+            return false;
+        }
+
+        vars.liquidationThresholdAfterDecrease =
+            (vars.collateralBalanceETH *
+                vars.currentLiquidationThreshold -
+                vars.amountToDecreaseETH *
+                vars.reserveLiquidationThreshold) /
+            vars.collateralBalancefterDecrease;
+
+        uint256 healthFactorAfterDecrease = dataProvider_calculateHealthFactorFromBalancesInternal(
+                vars.collateralBalancefterDecrease,
+                vars.borrowBalanceETH,
+                vars.totalFeesETH,
+                vars.liquidationThresholdAfterDecrease
+            );
+
+        return healthFactorAfterDecrease > 1e18;
+    }
+
+    function dataProvider_calculateHealthFactorFromBalancesInternal(
+        uint256 collateralBalanceETH,
+        uint256 borrowBalanceETH,
+        uint256 totalFeesETH,
+        uint256 liquidationThreshold
+    ) internal returns (uint256) {
+        if (borrowBalanceETH == 0) return type(uint256).max;
+
+        return
+            ((collateralBalanceETH * liquidationThreshold) / 100) /
+            (borrowBalanceETH + totalFeesETH);
+    }
+}

--- a/solidity-lite-syntax/examples/lending/LendingPool.sol
+++ b/solidity-lite-syntax/examples/lending/LendingPool.sol
@@ -1,0 +1,695 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+// The source code of this contract uses the following contracts
+// LendingPool: https://github.com/kaymen99/CryptoLendX/blob/main/contracts/LendingPool.sol
+
+interface AggregatorV3Interface {
+    function latestRoundData() external returns (uint256[] memory returndata);
+}
+
+interface IERC20 {
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(
+        address from,
+        address to,
+        uint value
+    ) external returns (bool);
+    function balanceOf(address account) external returns (uint256);
+    function decimals() external returns (uint8);
+}
+
+contract LendingPool {
+    enum TokenType {
+        ERC20,
+        ERC721
+    }
+
+    struct Vault {
+        uint128 amount;
+        uint128 shares;
+    }
+
+    struct AccountShares {
+        uint256 collateral;
+        uint256 borrow;
+    }
+
+    struct VaultInfo {
+        uint64 reserveRatio;
+        uint64 feeToProtocolRate;
+        uint64 flashFeeRate;
+        uint64 ratePerSec;
+        uint64 lastBlock;
+        uint64 lastTimestamp;
+        uint64 baseRate;
+        uint64 slope1;
+        uint64 slope2;
+        uint256 optimalUtilization;
+    }
+
+    struct TokenVault {
+        Vault totalAsset;
+        Vault totalBorrow;
+        VaultInfo vaultInfo;
+    }
+
+    struct VaultSetupParams {
+        uint64 reserveRatio;
+        uint64 feeToProtocolRate;
+        uint64 flashFeeRate;
+        uint64 baseRate;
+        uint64 slope1;
+        uint64 slope2;
+        uint256 optimalUtilization;
+    }
+
+    struct SupportedToken {
+        address usdPriceFeed;
+        TokenType tokenType;
+        bool supported;
+    }
+
+    uint256 internal MAX_PROTOCOL_FEE = 0.5e4; // 5%
+    uint256 public PRECISION = 1e18; // 18 decimals precision
+    uint256 public BPS = 1e5; // 5 decimals precision
+    uint256 public BLOCKS_PER_YEAR = 2102400; // Average Ethereum blocks per year
+    uint256 internal RATE_PRECISION = 1e18;
+    uint256 internal MIN_HEALTH_FACTOR = 1e18;
+    uint256 internal CLOSE_FACTOR_HF_THRESHOLD = 0.9e18;
+    uint256 internal LIQUIDATION_THRESHOLD = 8e4; // 80%
+    uint256 internal DEFAULT_LIQUIDATION_CLOSE_FACTOR = 5e4; // 50%
+    uint256 internal LIQUIDATION_REWARD = 5e3; // 5%
+
+    address[] internal supportedERC20s;
+    address[] internal supportedNFTs;
+
+    mapping(address => TokenVault) private vaults;
+    mapping(address => SupportedToken) internal supportedTokens;
+    mapping(address => mapping(address => AccountShares)) private userShares;
+
+    error TooHighSlippage(uint256 sharesOutOrAmountIn);
+    error InsufficientBalance();
+    error BelowHeathFactor();
+    error BorrowerIsSolvant();
+    error SelfLiquidation();
+    error InvalidFeeRate(uint256 fee);
+    error InvalidReserveRatio(uint256 ratio);
+    error InvalidPrice();
+    error AlreadySupported(address token);
+    error InvalidTokenType(TokenType tokenType);
+    error TransferFailed();
+
+    event AddSupportedToken(address token, TokenType tokenType);
+    event Deposit(address user, address token, uint256 amount, uint256 shares);
+    event Borrow(address user, address token, uint256 amount, uint256 shares);
+    event Repay(address user, address token, uint256 amount, uint256 shares);
+    event Withdraw(address user, address token, uint256 amount, uint256 shares);
+    event Liquidated(
+        address borrower,
+        address liquidator,
+        uint256 repaidAmount,
+        uint256 liquidatedCollateral,
+        uint256 reward
+    );
+    event UpdateInterestRate(uint256 elapsedTime, uint64 newInterestRate);
+    event AccruedInterest(
+        uint64 interestRatePerSec,
+        uint256 interestEarned,
+        uint256 feesAmount,
+        uint256 feesShare
+    );
+    event NewVaultSetup(address token, VaultSetupParams params);
+
+    constructor(
+        address daiAddress,
+        address daiPriceFeed,
+        VaultSetupParams memory daiVaultParams
+    ) {
+        _setupVault(
+            daiAddress,
+            daiPriceFeed,
+            TokenType.ERC20,
+            daiVaultParams,
+            true
+        );
+    }
+
+    function supply(
+        address token,
+        uint256 amount,
+        uint256 minSharesOut
+    ) external {
+        _accrueInterest(token);
+
+        _transferERC20(token, msg.sender, address(this), amount);
+        uint256 shares = _toShares(vaults[token].totalAsset, amount, false);
+        if (shares < minSharesOut) revert TooHighSlippage(shares);
+
+        vaults[token].totalAsset.shares += uint128(shares);
+        vaults[token].totalAsset.amount += uint128(amount);
+        userShares[msg.sender][token].collateral += shares;
+
+        emit Deposit(msg.sender, token, amount, shares);
+    }
+
+    function borrow(address token, uint256 amount) external {
+        if (!vaultAboveReserveRatio(token, amount))
+            revert InsufficientBalance();
+        _accrueInterest(token);
+
+        uint256 shares = _toShares(vaults[token].totalBorrow, amount, false);
+        vaults[token].totalBorrow.shares += uint128(shares);
+        vaults[token].totalBorrow.amount += uint128(amount);
+        userShares[msg.sender][token].borrow += shares;
+
+        _transferERC20(token, address(this), msg.sender, amount);
+        if (healthFactor(msg.sender) < MIN_HEALTH_FACTOR)
+            revert BelowHeathFactor();
+
+        emit Borrow(msg.sender, token, amount, shares);
+    }
+
+    function repay(address token, uint256 amount) external {
+        _accrueInterest(token);
+        uint256 userBorrowShare = userShares[msg.sender][token].borrow;
+        uint256 shares = _toShares(vaults[token].totalBorrow, amount, true);
+        if (amount == type(uint256).max || shares > userBorrowShare) {
+            shares = userBorrowShare;
+            amount = _toAmount(vaults[token].totalBorrow, shares, true);
+        }
+        _transferERC20(token, msg.sender, address(this), amount);
+        vaults[token].totalBorrow.shares -= uint128(shares);
+        vaults[token].totalBorrow.amount -= uint128(amount);
+        userShares[msg.sender][token].borrow = userBorrowShare - shares;
+        emit Repay(msg.sender, token, amount, shares);
+    }
+
+    function withdraw(
+        address token,
+        uint256 amount,
+        uint256 maxSharesIn
+    ) external {
+        _withdraw(token, amount, maxSharesIn, false);
+    }
+
+    function redeem(
+        address token,
+        uint256 shares,
+        uint256 minAmountOut
+    ) external {
+        _withdraw(token, shares, minAmountOut, true);
+    }
+
+    function liquidate(
+        address account,
+        address collateral,
+        address userBorrowToken,
+        uint256 amountToLiquidate
+    ) external {
+        if (msg.sender == account) revert SelfLiquidation();
+        uint256 accountHF = healthFactor(account);
+        if (accountHF >= MIN_HEALTH_FACTOR) revert BorrowerIsSolvant();
+        uint256 collateralShares = userShares[account][collateral].collateral;
+        uint256 borrowShares = userShares[account][userBorrowToken].borrow;
+        if (collateralShares == 0 || borrowShares == 0) return;
+        {
+            uint256 totalBorrowAmount = _toAmount(
+                vaults[userBorrowToken].totalBorrow,
+                borrowShares,
+                true
+            );
+
+            uint256 maxBorrowAmountToLiquidate = accountHF >=
+                CLOSE_FACTOR_HF_THRESHOLD
+                ? (totalBorrowAmount * DEFAULT_LIQUIDATION_CLOSE_FACTOR) / BPS
+                : totalBorrowAmount;
+            amountToLiquidate = amountToLiquidate > maxBorrowAmountToLiquidate
+                ? maxBorrowAmountToLiquidate
+                : amountToLiquidate;
+        }
+
+        uint256 collateralAmountToLiquidate;
+        uint256 liquidationReward;
+        {
+            address user = account;
+            address borrowToken = userBorrowToken;
+            address collToken = collateral;
+            uint256 liquidationAmount = amountToLiquidate;
+
+            uint256 _userTotalCollateralAmount = _toAmount(
+                vaults[collToken].totalAsset,
+                collateralShares,
+                false
+            );
+
+            collateralAmountToLiquidate =
+                (liquidationAmount *
+                    getTokenPrice(borrowToken) *
+                    10 ** IERC20(collToken).decimals()) /
+                (getTokenPrice(collToken) *
+                    10 ** IERC20(borrowToken).decimals());
+            uint256 maxLiquidationReward = (collateralAmountToLiquidate *
+                LIQUIDATION_REWARD) / BPS;
+            if (collateralAmountToLiquidate > _userTotalCollateralAmount) {
+                collateralAmountToLiquidate = _userTotalCollateralAmount;
+                liquidationAmount =
+                    ((_userTotalCollateralAmount *
+                        getTokenPrice(collToken) *
+                        10 ** IERC20(borrowToken).decimals()) /
+                        getTokenPrice(borrowToken)) *
+                    10 ** IERC20(collToken).decimals();
+                amountToLiquidate = liquidationAmount;
+            } else {
+                uint256 collateralBalanceAfter = _userTotalCollateralAmount -
+                    collateralAmountToLiquidate;
+                liquidationReward = maxLiquidationReward >
+                    collateralBalanceAfter
+                    ? collateralBalanceAfter
+                    : maxLiquidationReward;
+            }
+
+            uint128 repaidBorrowShares = uint128(
+                _toShares(
+                    vaults[borrowToken].totalBorrow,
+                    liquidationAmount,
+                    false
+                )
+            );
+            vaults[borrowToken].totalBorrow.shares -= repaidBorrowShares;
+            vaults[borrowToken].totalBorrow.amount -= uint128(
+                liquidationAmount
+            );
+
+            uint128 liquidatedCollShares = uint128(
+                _toShares(
+                    vaults[collToken].totalAsset,
+                    collateralAmountToLiquidate + liquidationReward,
+                    false
+                )
+            );
+            vaults[collToken].totalAsset.shares -= liquidatedCollShares;
+            vaults[collToken].totalAsset.amount -= uint128(
+                collateralAmountToLiquidate + liquidationReward
+            );
+            userShares[user][borrowToken].borrow -= repaidBorrowShares;
+            userShares[user][collToken].collateral -= liquidatedCollShares;
+        }
+
+        _transferERC20(
+            userBorrowToken,
+            msg.sender,
+            address(this),
+            amountToLiquidate
+        );
+        _transferERC20(
+            collateral,
+            address(this),
+            msg.sender,
+            collateralAmountToLiquidate + liquidationReward
+        );
+
+        emit Liquidated(
+            account,
+            msg.sender,
+            amountToLiquidate,
+            collateralAmountToLiquidate + liquidationReward,
+            liquidationReward
+        );
+    }
+
+    function getUserData(
+        address user
+    ) public returns (uint256[] memory returndata) {
+        returndata = new uint256[](2);
+
+        returndata[0] = getUserTotalTokenCollateral(user);
+        returndata[1] = getUserTotalBorrow(user);
+    }
+
+    function getUserTotalTokenCollateral(
+        address user
+    ) public returns (uint256 totalValueUSD) {
+        uint256 len = supportedERC20s.length;
+        for (uint256 i; i < len; i++) {
+            address token = supportedERC20s[i];
+            uint256 tokenAmount = _toAmount(
+                vaults[token].totalAsset,
+                userShares[user][token].collateral,
+                false
+            );
+            if (tokenAmount != 0) {
+                totalValueUSD += getAmountInUSD(token, tokenAmount);
+            }
+        }
+    }
+
+    function getUserTotalBorrow(
+        address user
+    ) public returns (uint256 totalValueUSD) {
+        uint256 len = supportedERC20s.length;
+        for (uint256 i; i < len; i++) {
+            address token = supportedERC20s[i];
+            uint256 tokenAmount = _toAmount(
+                vaults[token].totalBorrow,
+                userShares[user][token].borrow,
+                false
+            );
+            if (tokenAmount != 0) {
+                totalValueUSD += getAmountInUSD(token, tokenAmount);
+            }
+        }
+    }
+
+    function getUserTokenCollateralAndBorrow(
+        address user,
+        address token
+    ) external returns (uint256[] memory returndata) {
+        returndata = new uint256[](2);
+        returndata[0] = userShares[user][token].collateral;
+        returndata[1] = userShares[user][token].borrow;
+    }
+
+    function healthFactor(address user) public returns (uint256 factor) {
+        uint256[] memory returndata = getUserData(user);
+
+        uint256 userTotalCollateralValue = returndata[0];
+        if (returndata[1] == 0) return 100 * MIN_HEALTH_FACTOR;
+        uint256 collateralValueWithThreshold = (userTotalCollateralValue *
+            LIQUIDATION_THRESHOLD) / BPS;
+        factor =
+            (collateralValueWithThreshold * MIN_HEALTH_FACTOR) /
+            returndata[1];
+    }
+
+    function getAmountInUSD(
+        address token,
+        uint256 amount
+    ) public returns (uint256 value) {
+        uint256 price = getTokenPrice(token);
+        uint8 decimals = IERC20(token).decimals();
+        uint256 amountIn18Decimals = amount * 10 ** (18 - decimals);
+        // return USD value scaled by 18 decimals
+        value = (amountIn18Decimals * price) / PRECISION;
+    }
+
+    function getTokenVault(
+        address token
+    ) public returns (TokenVault memory vault) {
+        vault = vaults[token];
+    }
+
+    function amountToShares(
+        address token,
+        uint256 amount,
+        bool isAsset
+    ) external returns (uint256 shares) {
+        if (isAsset) {
+            shares = uint256(
+                _toShares(vaults[token].totalAsset, amount, false)
+            );
+        } else {
+            shares = uint256(
+                _toShares(vaults[token].totalBorrow, amount, false)
+            );
+        }
+    }
+
+    function sharesToAmount(
+        address token,
+        uint256 shares,
+        bool isAsset
+    ) external returns (uint256 amount) {
+        if (isAsset) {
+            amount = uint256(
+                _toAmount(vaults[token].totalAsset, shares, false)
+            );
+        } else {
+            amount = uint256(
+                _toAmount(vaults[token].totalBorrow, shares, false)
+            );
+        }
+    }
+
+    function setupVault(
+        address token,
+        address priceFeed,
+        TokenType tokenType,
+        VaultSetupParams memory params,
+        bool addToken
+    ) external {
+        _setupVault(token, priceFeed, tokenType, params, addToken);
+    }
+
+    function vaultAboveReserveRatio(
+        address token,
+        uint256 pulledAmount
+    ) internal returns (bool isAboveReserveRatio) {
+        uint256 minVaultReserve = (vaults[token].totalAsset.amount *
+            vaults[token].vaultInfo.reserveRatio) / BPS;
+        isAboveReserveRatio =
+            vaults[token].totalAsset.amount != 0 &&
+            IERC20(token).balanceOf(address(this)) >=
+            minVaultReserve + pulledAmount;
+    }
+
+    function _withdraw(
+        address token,
+        uint256 amount,
+        uint256 minAmountOutOrMaxShareIn,
+        bool share
+    ) internal {
+        _accrueInterest(token);
+        uint256 userCollShares = userShares[msg.sender][token].collateral;
+        uint256 shares;
+        if (share) {
+            shares = amount;
+            amount = _toAmount(vaults[token].totalAsset, shares, false);
+            if (amount < minAmountOutOrMaxShareIn)
+                revert TooHighSlippage(amount);
+        } else {
+            shares = _toShares(vaults[token].totalAsset, amount, false);
+            if (shares > minAmountOutOrMaxShareIn)
+                revert TooHighSlippage(shares);
+        }
+        if (
+            userCollShares < shares ||
+            IERC20(token).balanceOf(address(this)) < amount
+        ) revert InsufficientBalance();
+        vaults[token].totalAsset.shares -= uint128(shares);
+        vaults[token].totalAsset.amount -= uint128(amount);
+        userShares[msg.sender][token].collateral -= shares;
+
+        _transferERC20(token, address(this), msg.sender, amount);
+        if (healthFactor(msg.sender) < MIN_HEALTH_FACTOR)
+            revert BelowHeathFactor();
+        emit Withdraw(msg.sender, token, amount, shares);
+    }
+
+    function _accrueInterest(address token) internal {
+        uint256 _interestEarned;
+        uint256 _feesAmount;
+        uint256 _feesShare;
+        uint64 newRate;
+
+        TokenVault memory _vault = vaults[token];
+        if (_vault.totalAsset.amount == 0) {
+            return;
+        }
+
+        VaultInfo memory _currentRateInfo = _vault.vaultInfo;
+        if (_currentRateInfo.lastTimestamp == block.timestamp) {
+            newRate = _currentRateInfo.ratePerSec;
+            return;
+        }
+
+        if (_vault.totalBorrow.shares == 0) {
+            _currentRateInfo.lastTimestamp = uint64(block.timestamp);
+            _currentRateInfo.lastBlock = uint64(block.number);
+            _vault.vaultInfo = _currentRateInfo;
+        } else {
+            uint256 _deltaTime = block.number - _currentRateInfo.lastBlock;
+            uint256 _utilization = (_vault.totalBorrow.amount * PRECISION) /
+                _vault.totalAsset.amount;
+            uint256 _newRate = _calculateInterestRate(
+                _currentRateInfo,
+                _utilization
+            );
+            _currentRateInfo.ratePerSec = uint64(_newRate);
+            _currentRateInfo.lastTimestamp = uint64(block.timestamp);
+            _currentRateInfo.lastBlock = uint64(block.number);
+
+            emit UpdateInterestRate(_deltaTime, uint64(_newRate));
+
+            _interestEarned =
+                (_deltaTime *
+                    _vault.totalBorrow.amount *
+                    _currentRateInfo.ratePerSec) /
+                (PRECISION * BLOCKS_PER_YEAR);
+
+            _vault.totalBorrow.amount += uint128(_interestEarned);
+            _vault.totalAsset.amount += uint128(_interestEarned);
+            _vault.vaultInfo = _currentRateInfo;
+            if (_currentRateInfo.feeToProtocolRate > 0) {
+                _feesAmount =
+                    (_interestEarned * _currentRateInfo.feeToProtocolRate) /
+                    BPS;
+                _feesShare =
+                    (_feesAmount * _vault.totalAsset.shares) /
+                    (_vault.totalAsset.amount - _feesAmount);
+                _vault.totalAsset.shares += uint128(_feesShare);
+
+                userShares[address(this)][token].collateral += _feesShare;
+            }
+            emit AccruedInterest(
+                _currentRateInfo.ratePerSec,
+                _interestEarned,
+                _feesAmount,
+                _feesShare
+            );
+        }
+        vaults[token] = _vault;
+    }
+
+    function _setupVault(
+        address token,
+        address priceFeed,
+        TokenType tokenType,
+        VaultSetupParams memory params,
+        bool addToken
+    ) internal {
+        if (addToken) {
+            _addSupportedToken(token, priceFeed, tokenType);
+        }
+        if (tokenType == TokenType.ERC20) {
+            if (params.reserveRatio > BPS)
+                revert InvalidReserveRatio(params.reserveRatio);
+            if (params.feeToProtocolRate > MAX_PROTOCOL_FEE)
+                revert InvalidFeeRate(params.feeToProtocolRate);
+            if (params.flashFeeRate > MAX_PROTOCOL_FEE)
+                revert InvalidFeeRate(params.flashFeeRate);
+            VaultInfo storage _vaultInfo = vaults[token].vaultInfo;
+            _vaultInfo.reserveRatio = params.reserveRatio;
+            _vaultInfo.feeToProtocolRate = params.feeToProtocolRate;
+            _vaultInfo.flashFeeRate = params.flashFeeRate;
+            _vaultInfo.optimalUtilization = params.optimalUtilization;
+            _vaultInfo.baseRate = params.baseRate;
+            _vaultInfo.slope1 = params.slope1;
+            _vaultInfo.slope2 = params.slope2;
+
+            emit NewVaultSetup(token, params);
+        }
+    }
+
+    function _addSupportedToken(
+        address token,
+        address priceFeed,
+        TokenType tokenType
+    ) internal {
+        if (supportedTokens[token].supported) revert AlreadySupported(token);
+        if (uint256(tokenType) > 1) revert InvalidTokenType(tokenType);
+
+        supportedTokens[token].usdPriceFeed = priceFeed;
+        supportedTokens[token].tokenType = tokenType;
+        supportedTokens[token].supported = true;
+
+        if (tokenType == TokenType.ERC721) {
+            supportedNFTs.push(token);
+        } else {
+            supportedERC20s.push(token);
+        }
+
+        emit AddSupportedToken(token, tokenType);
+    }
+
+    function getTokenPrice(address token) public returns (uint256 price) {
+        if (!supportedTokens[token].supported) return 0;
+        AggregatorV3Interface priceFeed = AggregatorV3Interface(
+            supportedTokens[token].usdPriceFeed
+        );
+        price = _getPrice(priceFeed);
+    }
+    function _getPrice(
+        AggregatorV3Interface priceFeed
+    ) internal returns (uint256 price) {
+        uint256[] memory returndata = priceFeed.latestRoundData();
+        uint256 roundId = returndata[0];
+        uint256 answer = returndata[1];
+        uint256 updatedAt = returndata[3];
+        uint256 answeredInRound = returndata[4];
+
+        if (answer <= 0 || updatedAt == 0 || answeredInRound < roundId)
+            revert InvalidPrice();
+
+        price = answer;
+    }
+
+    function _transferERC20(
+        address _token,
+        address _from,
+        address _to,
+        uint256 _amount
+    ) internal {
+        bool success;
+        if (_from == address(this)) {
+            success = IERC20(_token).transfer(_to, _amount);
+        } else {
+            success = IERC20(_token).transferFrom(_from, _to, _amount);
+        }
+        if (!success) revert TransferFailed();
+    }
+
+    function _toShares(
+        Vault memory total,
+        uint256 amount,
+        bool roundUp
+    ) internal returns (uint256 shares) {
+        if (total.amount == 0) {
+            shares = amount;
+        } else {
+            shares = (amount * total.shares) / total.amount;
+            if (roundUp && (shares * total.amount) / total.shares < amount) {
+                shares = shares + 1;
+            }
+        }
+    }
+
+    function _toAmount(
+        Vault memory total,
+        uint256 shares,
+        bool roundUp
+    ) internal returns (uint256 amount) {
+        if (total.shares == 0) {
+            amount = shares;
+        } else {
+            amount = (shares * total.amount) / total.shares;
+            if (roundUp && (amount * total.shares) / total.amount < shares) {
+                amount = amount + 1;
+            }
+        }
+    }
+
+    function _calculateInterestRate(
+        VaultInfo memory _interestRateInfo,
+        uint256 utilization
+    ) internal returns (uint256 newRatePerSec) {
+        uint256 optimalUtilization = _interestRateInfo.optimalUtilization;
+        uint256 baseRate = uint256(_interestRateInfo.baseRate);
+        uint256 slope1 = uint256(_interestRateInfo.slope1);
+        uint256 slope2 = uint256(_interestRateInfo.slope2);
+
+        if (utilization <= optimalUtilization) {
+            uint256 rate = (utilization * slope1) / optimalUtilization;
+            newRatePerSec = baseRate + rate;
+        } else {
+            uint256 utilizationDelta = utilization - optimalUtilization;
+            uint256 excessUtilizationRate = (utilizationDelta *
+                RATE_PRECISION) / (RATE_PRECISION - optimalUtilization);
+            newRatePerSec =
+                baseRate +
+                slope1 +
+                (excessUtilizationRate * slope2) /
+                RATE_PRECISION;
+        }
+    }
+}

--- a/solidity-lite-syntax/examples/staking/LidoStaking.sol
+++ b/solidity-lite-syntax/examples/staking/LidoStaking.sol
@@ -1,0 +1,905 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.25;
+
+// The source code of this contract uses the following contracts from Lido v0.4.24
+// Lido: https://github.com/lidofinance/core/blob/master/contracts/0.4.24/Lido.sol
+// StETH: https://github.com/lidofinance/core/blob/master/contracts/0.4.24/StETH.sol
+
+interface IPostTokenRebaseReceiver {
+    function handlePostTokenRebase(
+        uint256 _reportTimestamp,
+        uint256 _timeElapsed,
+        uint256 _preTotalShares,
+        uint256 _preTotalEther,
+        uint256 _postTotalShares,
+        uint256 _postTotalEther,
+        uint256 _sharesMintedAsFees
+    ) external;
+}
+
+interface IOracleReportSanityChecker {
+    function checkAccountingOracleReport(
+        uint256 _timeElapsed,
+        uint256 _preCLBalance,
+        uint256 _postCLBalance,
+        uint256 _withdrawalVaultBalance,
+        uint256 _elRewardsVaultBalance,
+        uint256 _sharesRequestedToBurn,
+        uint256 _preCLValidators,
+        uint256 _postCLValidators
+    ) external;
+
+    function smoothenTokenRebase(
+        uint256 _preTotalPooledEther,
+        uint256 _preTotalShares,
+        uint256 _preCLBalance,
+        uint256 _postCLBalance,
+        uint256 _withdrawalVaultBalance,
+        uint256 _elRewardsVaultBalance,
+        uint256 _sharesRequestedToBurn,
+        uint256 _etherToLockForWithdrawals,
+        uint256 _newSharesToBurnForWithdrawals
+    ) external returns (uint256[] memory return_data);
+
+    function checkWithdrawalQueueOracleReport(
+        uint256 _lastFinalizableRequestId,
+        uint256 _reportTimestamp
+    ) external;
+
+    function checkSimulatedShareRate(
+        uint256 _postTotalPooledEther,
+        uint256 _postTotalShares,
+        uint256 _etherLockedOnWithdrawalQueue,
+        uint256 _sharesBurntDueToWithdrawals,
+        uint256 _simulatedShareRate
+    ) external;
+}
+
+interface ILidoExecutionLayerRewardsVault {
+    function withdrawRewards(uint256 _maxAmount) external returns (uint256 amount);
+}
+
+interface IWithdrawalVault {
+    function withdrawWithdrawals(uint256 _amount) external;
+}
+
+interface IStakingRouter {
+
+    function deposit(
+        uint256 _depositsCount,
+        uint256 _stakingModuleId,
+        bytes memory _depositCalldata
+    ) external payable;
+
+    function getStakingRewardsDistribution()
+        external returns (Lido.StakingRewardsDistribution memory return_data);
+
+    function reportRewardsMinted(uint256[] memory _stakingModuleIds, uint256[] memory _totalShares) external;
+
+    function getStakingModuleMaxDepositsCount(uint256 _stakingModuleId, uint256 _maxDepositsValue)
+        external
+        returns (uint256);
+}
+
+interface IWithdrawalQueue {
+    function prefinalize(uint256[] memory _batches, uint256 _maxShareRate)
+        external returns (uint256[] memory return_data);
+
+    function finalize(uint256 _lastIdToFinalize, uint256 _maxShareRate) external payable;
+
+    function unfinalizedStETH() external returns (uint256);
+
+    function isBunkerModeActive() external returns (bool);
+}
+
+interface IBurner {
+    function commitSharesToBurn(uint256 _stETHSharesToBurn) external;
+    function requestBurnShares(address _from, uint256 _sharesAmount) external;
+}
+
+interface ILidoLocatorMock{
+    function burner() external returns(address);
+    function stakingRouter() external returns(address);
+    function treasury() external returns(address);
+    function withdrawalQueue() external returns(address);
+    function withdrawalVault() external returns(address);
+    function elRewardsVault() external returns(address);
+    function oracleReportComponentsForLido() external returns(address[] memory return_data);
+}
+
+
+contract Lido{
+
+    uint256 private DEPOSIT_SIZE = 32 ether;
+
+    address internal LIDO_LOCATOR_POSITION; 
+    uint256 public BUFFERED_ETHER_POSITION; 
+    uint256 internal DEPOSITED_VALIDATORS_POSITION; 
+    uint256 internal CL_BALANCE_POSITION; 
+    uint256 internal CL_VALIDATORS_POSITION; 
+    uint256 internal TOTAL_EL_REWARDS_COLLECTED_POSITION; 
+
+    /*stETH variables start*/
+    address internal INITIAL_TOKEN_HOLDER = address(0xdead);
+    uint256 internal INFINITE_ALLOWANCE = type(uint256).max;
+    mapping (address => uint256) private shares;
+    mapping (address => mapping (address => uint256)) private allowances;
+    uint256 internal TOTAL_SHARES_POSITION;
+    /*stETH variables end*/
+
+    struct OracleReportedData {
+        uint256 reportTimestamp;
+        uint256 timeElapsed;
+        uint256 clValidators;
+        uint256 postCLBalance;
+        uint256 withdrawalVaultBalance;
+        uint256 elRewardsVaultBalance;
+        uint256 sharesRequestedToBurn;
+        uint256[] withdrawalFinalizationBatches;
+        uint256 simulatedShareRate;
+    }
+
+    struct OracleReportContracts {
+        address accountingOracle;
+        address elRewardsVault;
+        address oracleReportSanityChecker;
+        address burner;
+        address withdrawalQueue;
+        address withdrawalVault;
+        address postTokenRebaseReceiver;
+    }
+
+    struct StakingRewardsDistribution {
+        address[] recipients;
+        uint256[] moduleIds;
+        uint256[] modulesFees;
+        uint256 totalFee;
+        uint256 precisionPoints;
+    }
+    
+    struct StakingRewardsDistributionReturnData{
+        StakingRewardsDistribution distributionData;
+        IStakingRouter router;
+    }
+
+    struct OracleReportContext {
+        uint256 preCLValidators;
+        uint256 preCLBalance;
+        uint256 preTotalPooledEther;
+        uint256 preTotalShares;
+        uint256 etherToLockOnWithdrawalQueue;
+        uint256 sharesToBurnFromWithdrawalQueue;
+        uint256 simulatedSharesToBurn;
+        uint256 sharesToBurn;
+        uint256 sharesMintedAsFees;
+    }
+
+
+    event CLValidatorsUpdated(
+        uint256 indexed reportTimestamp,
+        uint256 preCLValidators,
+        uint256 postCLValidators
+    );
+
+    event DepositedValidatorsChanged(
+        uint256 depositedValidators
+    );
+
+    event ETHDistributed(
+        uint256 indexed reportTimestamp,
+        uint256 preCLBalance,
+        uint256 postCLBalance,
+        uint256 withdrawalsWithdrawn,
+        uint256 executionLayerRewardsWithdrawn,
+        uint256 postBufferedEther
+    );
+
+    event TokenRebased(
+        uint256 indexed reportTimestamp,
+        uint256 timeElapsed,
+        uint256 preTotalShares,
+        uint256 preTotalEther,
+        uint256 postTotalShares,
+        uint256 postTotalEther,
+        uint256 sharesMintedAsFees
+    );
+
+    event LidoLocatorSet(address lidoLocator);
+    event ELRewardsReceived(uint256 amount);
+    event WithdrawalsReceived(uint256 amount);
+    event Submitted(address indexed sender, uint256 amount, address referral);
+    event Unbuffered(uint256 amount);
+
+    /*stETH events start*/
+    event TransferShares(
+        address indexed from,
+        address indexed to,
+        uint256 sharesValue
+    );
+ 
+    event SharesBurnt(
+        address indexed account,
+        uint256 preRebaseTokenAmount,
+        uint256 postRebaseTokenAmount,
+        uint256 sharesAmount
+    );
+    /*stETH events end*/
+
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    function initialize(address _lidoLocator) public payable {
+        uint256 balance = address(this).balance;
+        assert(balance != 0);
+
+        if (_getTotalShares() == 0) {
+            _setBufferedEther(balance);
+            emit Submitted(INITIAL_TOKEN_HOLDER, balance, address(0));
+            _mintInitialShares(balance);
+        }
+
+        LIDO_LOCATOR_POSITION = _lidoLocator;
+
+        _approve(
+            ILidoLocatorMock(_lidoLocator).withdrawalQueue(),
+            ILidoLocatorMock(_lidoLocator).burner(),
+            INFINITE_ALLOWANCE
+        );
+
+        emit LidoLocatorSet(_lidoLocator);
+    }
+
+    function submit(address _referral) external payable returns (uint256) {
+        return _submit(_referral);
+    }
+
+    function receiveELRewards() external payable {
+        require(msg.sender == getLidoLocator().elRewardsVault());
+
+        TOTAL_EL_REWARDS_COLLECTED_POSITION = getTotalELRewardsCollected() + msg.value;
+
+        emit ELRewardsReceived(msg.value);
+    }
+
+    function receiveWithdrawals() external payable {
+        require(msg.sender == getLidoLocator().withdrawalVault());
+
+        emit WithdrawalsReceived(msg.value);
+    }
+
+    function handleOracleReport(
+        uint256 _reportTimestamp,
+        uint256 _timeElapsed,
+        uint256 _clValidators,
+        uint256 _clBalance,
+        uint256 _withdrawalVaultBalance,
+        uint256 _elRewardsVaultBalance,
+        uint256 _sharesRequestedToBurn,
+        uint256[] memory _withdrawalFinalizationBatches,
+        uint256 _simulatedShareRate
+    ) external returns (uint256[4] memory postRebaseAmounts) {
+
+        return _handleOracleReport(
+            OracleReportedData(
+                _reportTimestamp,
+                _timeElapsed,
+                _clValidators,
+                _clBalance,
+                _withdrawalVaultBalance,
+                _elRewardsVaultBalance,
+                _sharesRequestedToBurn,
+                _withdrawalFinalizationBatches,
+                _simulatedShareRate
+            )
+        );
+    }
+
+    function getBufferedEther() external returns (uint256) {
+        return BUFFERED_ETHER_POSITION;
+    }
+
+    function getTotalELRewardsCollected() public returns (uint256) {
+        return TOTAL_EL_REWARDS_COLLECTED_POSITION;
+    }
+
+    function getLidoLocator() public returns (ILidoLocatorMock) {
+        return ILidoLocatorMock(LIDO_LOCATOR_POSITION);
+    }
+
+    function getBeaconStat() external returns (uint256 depositedValidators, uint256 beaconValidators, uint256 beaconBalance) {
+        depositedValidators = DEPOSITED_VALIDATORS_POSITION;
+        beaconValidators = CL_VALIDATORS_POSITION;
+        beaconBalance = CL_BALANCE_POSITION;
+    }
+    
+    function getTreasury() external returns (address) {
+        return _treasury();
+    }
+
+    function canDeposit() public returns (bool) {
+        return !_withdrawalQueue().isBunkerModeActive();
+    }
+
+    function getDepositableEther() public returns (uint256) {
+        uint256 bufferedEther = BUFFERED_ETHER_POSITION;
+        uint256 withdrawalReserve = _withdrawalQueue().unfinalizedStETH();
+        return bufferedEther > withdrawalReserve ? bufferedEther - withdrawalReserve : 0;
+    }
+
+    function deposit(uint256 _maxDepositsCount, uint256 _stakingModuleId, bytes memory _depositCalldata) external {
+        //LidoLocatorMock locator = getLidoLocator();
+
+        require(canDeposit(), "CAN_NOT_DEPOSIT");
+
+        IStakingRouter stakingRouter = _stakingRouter();
+        uint256 depositsCount = _min(
+            _maxDepositsCount,
+            stakingRouter.getStakingModuleMaxDepositsCount(_stakingModuleId, getDepositableEther())
+        );
+
+        uint256 depositsValue;
+        if (depositsCount > 0) {
+            depositsValue = depositsCount * DEPOSIT_SIZE;
+            BUFFERED_ETHER_POSITION = BUFFERED_ETHER_POSITION - depositsValue;
+            emit Unbuffered(depositsValue);
+
+            uint256 newDepositedValidators = DEPOSITED_VALIDATORS_POSITION + depositsCount;
+            DEPOSITED_VALIDATORS_POSITION = newDepositedValidators;
+            emit DepositedValidatorsChanged(newDepositedValidators);
+        }
+
+        stakingRouter.deposit{value: depositsValue}(depositsCount, _stakingModuleId, _depositCalldata);
+    }
+
+    function _min(uint256 a, uint256 b) internal returns(uint256 min){
+        min = a < b ? a : b;
+    }
+
+    function _processClStateUpdate(
+        uint256 _reportTimestamp,
+        uint256 _preClValidators,
+        uint256 _postClValidators,
+        uint256 _postClBalance
+    ) internal returns (uint256 preCLBalance) {
+        uint256 depositedValidators = DEPOSITED_VALIDATORS_POSITION;
+        require(_postClValidators <= depositedValidators, "REPORTED_MORE_DEPOSITED");
+        require(_postClValidators >= _preClValidators, "REPORTED_LESS_VALIDATORS");
+
+        if (_postClValidators > _preClValidators) {
+            CL_VALIDATORS_POSITION = _postClValidators;
+        }
+
+        uint256 appearedValidators = _postClValidators - _preClValidators;
+        preCLBalance = CL_BALANCE_POSITION;
+        preCLBalance = preCLBalance + appearedValidators * DEPOSIT_SIZE;
+
+        CL_BALANCE_POSITION = _postClBalance;
+
+        emit CLValidatorsUpdated(_reportTimestamp, _preClValidators, _postClValidators);
+    }
+
+    function _collectRewardsAndProcessWithdrawals(
+        OracleReportContracts memory _contracts,
+        uint256 _withdrawalsToWithdraw,
+        uint256 _elRewardsToWithdraw,
+        uint256[] memory _withdrawalFinalizationBatches,
+        uint256 _simulatedShareRate,
+        uint256 _etherToLockOnWithdrawalQueue
+    ) internal {
+        if (_elRewardsToWithdraw > 0) {
+            ILidoExecutionLayerRewardsVault(_contracts.elRewardsVault).withdrawRewards(_elRewardsToWithdraw);
+        }
+
+        if (_withdrawalsToWithdraw > 0) {
+            IWithdrawalVault(_contracts.withdrawalVault).withdrawWithdrawals(_withdrawalsToWithdraw);
+        }
+
+        if (_etherToLockOnWithdrawalQueue > 0) {
+            IWithdrawalQueue withdrawalQueue = IWithdrawalQueue(_contracts.withdrawalQueue);
+            withdrawalQueue.finalize{value: _etherToLockOnWithdrawalQueue}(
+                _withdrawalFinalizationBatches[_withdrawalFinalizationBatches.length - 1],
+                _simulatedShareRate
+            );
+        }
+
+        uint256 postBufferedEther = BUFFERED_ETHER_POSITION + _elRewardsToWithdraw + _withdrawalsToWithdraw - _etherToLockOnWithdrawalQueue; 
+
+        _setBufferedEther(postBufferedEther);
+    }
+
+    function _calculateWithdrawals(
+        OracleReportContracts memory _contracts,
+        OracleReportedData memory _reportedData
+    ) internal returns (uint256[] memory return_data) {
+        IWithdrawalQueue withdrawalQueue = IWithdrawalQueue(_contracts.withdrawalQueue);
+
+        IOracleReportSanityChecker(_contracts.oracleReportSanityChecker).checkWithdrawalQueueOracleReport(
+            _reportedData.withdrawalFinalizationBatches[_reportedData.withdrawalFinalizationBatches.length - 1],
+            _reportedData.reportTimestamp
+        );
+
+        return withdrawalQueue.prefinalize(
+            _reportedData.withdrawalFinalizationBatches,
+            _reportedData.simulatedShareRate
+        );
+    }
+
+    function _processRewards(
+        OracleReportContext memory _reportContext,
+        uint256 _postCLBalance,
+        uint256 _withdrawnWithdrawals,
+        uint256 _withdrawnElRewards
+    ) internal returns (uint256 sharesMintedAsFees) {
+        uint256 postCLTotalBalance = _postCLBalance + _withdrawnWithdrawals;
+        if (postCLTotalBalance > _reportContext.preCLBalance) {
+            uint256 consensusLayerRewards = postCLTotalBalance - _reportContext.preCLBalance;
+
+            sharesMintedAsFees = _distributeFee(
+                _reportContext.preTotalPooledEther,
+                _reportContext.preTotalShares,
+                consensusLayerRewards + _withdrawnElRewards
+            );
+        }
+    }
+
+    function _submit(address _referral) internal returns (uint256) {
+        require(msg.value != 0, "ZERO_DEPOSIT");
+
+        uint256 sharesAmount = getSharesByPooledEth(msg.value);
+
+        _mintShares(msg.sender, sharesAmount);
+
+        _setBufferedEther(BUFFERED_ETHER_POSITION + msg.value);
+        emit Submitted(msg.sender, msg.value, _referral);
+
+        _emitTransferAfterMintingShares(msg.sender, sharesAmount);
+        return sharesAmount;
+    }
+
+    function _getStakingRewardsDistribution() internal returns (StakingRewardsDistributionReturnData memory return_data) {
+        return_data.router = _stakingRouter();
+        return_data.distributionData = return_data.router.getStakingRewardsDistribution();
+        
+        require(return_data.distributionData.recipients.length == return_data.distributionData.modulesFees.length, "WRONG_RECIPIENTS_INPUT");
+        require(return_data.distributionData.moduleIds.length == return_data.distributionData.modulesFees.length, "WRONG_MODULE_IDS_INPUT");
+    }
+
+    function _distributeFee(
+        uint256 _preTotalPooledEther,
+        uint256 _preTotalShares,
+        uint256 _totalRewards
+    ) internal returns (uint256 sharesMintedAsFees) {
+        StakingRewardsDistributionReturnData memory return_data = _getStakingRewardsDistribution();
+        StakingRewardsDistribution memory rewardsDistribution = return_data.distributionData;
+        IStakingRouter router = return_data.router;
+
+        if (rewardsDistribution.totalFee > 0) {
+            uint256 totalPooledEtherWithRewards = _preTotalPooledEther + _totalRewards;
+
+            sharesMintedAsFees =
+                _totalRewards * rewardsDistribution.totalFee * _preTotalShares / 
+                         ( totalPooledEtherWithRewards * rewardsDistribution.precisionPoints - ( _totalRewards*rewardsDistribution.totalFee ) );
+
+            _mintShares(address(this), sharesMintedAsFees);
+
+            uint256[] memory moduleRewardsAndTotal = _transferModuleRewards(
+                                                        rewardsDistribution.recipients,
+                                                        rewardsDistribution.modulesFees,
+                                                        rewardsDistribution.totalFee,
+                                                        sharesMintedAsFees
+                                                    );
+            uint256 totalModuleRewards = moduleRewardsAndTotal[moduleRewardsAndTotal.length - 1];
+            uint256[] memory moduleRewards = new uint256[](moduleRewardsAndTotal.length - 1);
+
+            for(uint i =0; i<moduleRewards.length; i++)
+                moduleRewards[i] = moduleRewardsAndTotal[i];
+
+            _transferTreasuryRewards(sharesMintedAsFees - totalModuleRewards);
+
+            router.reportRewardsMinted(
+                rewardsDistribution.moduleIds,
+                moduleRewards
+            );
+        }
+    }
+
+    function _transferModuleRewards(
+        address[] memory recipients,
+        uint256[] memory modulesFees,
+        uint256 totalFee,
+        uint256 totalRewards
+    ) internal returns (uint256[] memory moduleRewardsAndTotal) {
+        moduleRewardsAndTotal = new uint256[](recipients.length + 1);
+        uint256 totalModuleRewards;
+
+        for (uint256 i; i < recipients.length; ++i) {
+            if (modulesFees[i] > 0) {
+                uint256 iModuleRewards = totalRewards * modulesFees[i] / totalFee;
+                moduleRewardsAndTotal[i] = iModuleRewards;
+                _transferShares(address(this), recipients[i], iModuleRewards);
+                _emitTransferAfterMintingShares(recipients[i], iModuleRewards);
+                totalModuleRewards = totalModuleRewards + iModuleRewards;
+            }
+        }
+        moduleRewardsAndTotal[recipients.length] = totalModuleRewards;
+    }
+
+    function _transferTreasuryRewards(uint256 treasuryReward) internal {
+        address treasury = _treasury();
+        _transferShares(address(this), treasury, treasuryReward);
+        _emitTransferAfterMintingShares(treasury, treasuryReward);
+    }
+
+    function _setBufferedEther(uint256 _newBufferedEther) internal {
+        BUFFERED_ETHER_POSITION = _newBufferedEther;
+    }
+
+    function _getTransientBalance() internal returns (uint256) {
+        uint256 depositedValidators = DEPOSITED_VALIDATORS_POSITION;
+        uint256 clValidators = CL_VALIDATORS_POSITION;
+        assert(depositedValidators >= clValidators);
+        return (depositedValidators - clValidators) * DEPOSIT_SIZE;
+    }
+
+    function _getTotalPooledEther() internal returns (uint256) {
+        return BUFFERED_ETHER_POSITION + CL_BALANCE_POSITION + _getTransientBalance();
+    }
+
+    function _handleOracleReport(OracleReportedData memory _reportedData) internal returns (uint256[4] memory) {
+        OracleReportContracts memory contracts = _loadOracleReportContracts();
+
+        require(msg.sender == contracts.accountingOracle, "APP_AUTH_FAILED");
+        require(_reportedData.reportTimestamp <= block.timestamp, "INVALID_REPORT_TIMESTAMP");
+
+        OracleReportContext memory reportContext;
+
+        reportContext.preTotalPooledEther = _getTotalPooledEther();
+        reportContext.preTotalShares = _getTotalShares();
+        reportContext.preCLValidators = CL_VALIDATORS_POSITION;
+        reportContext.preCLBalance = _processClStateUpdate(
+            _reportedData.reportTimestamp,
+            reportContext.preCLValidators,
+            _reportedData.clValidators,
+            _reportedData.postCLBalance
+        );
+
+        _checkAccountingOracleReport(contracts, _reportedData, reportContext);
+
+        if (_reportedData.withdrawalFinalizationBatches.length != 0) {
+            uint256[] memory withdrawals_return_data = _calculateWithdrawals(contracts, _reportedData);
+            reportContext.etherToLockOnWithdrawalQueue = withdrawals_return_data[0];
+            reportContext.sharesToBurnFromWithdrawalQueue = withdrawals_return_data[1];
+
+            if (reportContext.sharesToBurnFromWithdrawalQueue > 0) {
+                IBurner(contracts.burner).requestBurnShares(
+                    contracts.withdrawalQueue,
+                    reportContext.sharesToBurnFromWithdrawalQueue
+                );
+            }
+        }
+
+        uint256 withdrawals;
+        uint256 elRewards;
+        
+        uint256[] memory sanity_checker_return_data = IOracleReportSanityChecker(contracts.oracleReportSanityChecker).smoothenTokenRebase(
+            reportContext.preTotalPooledEther,
+            reportContext.preTotalShares,
+            reportContext.preCLBalance,
+            _reportedData.postCLBalance,
+            _reportedData.withdrawalVaultBalance,
+            _reportedData.elRewardsVaultBalance,
+            _reportedData.sharesRequestedToBurn,
+            reportContext.etherToLockOnWithdrawalQueue,
+            reportContext.sharesToBurnFromWithdrawalQueue
+        );
+        
+        withdrawals = sanity_checker_return_data[0];
+        elRewards = sanity_checker_return_data[1];
+        reportContext.simulatedSharesToBurn = sanity_checker_return_data[2];
+        reportContext.sharesToBurn = sanity_checker_return_data[3];
+
+        _collectRewardsAndProcessWithdrawals(
+            contracts,
+            withdrawals,
+            elRewards,
+            _reportedData.withdrawalFinalizationBatches,
+            _reportedData.simulatedShareRate,
+            reportContext.etherToLockOnWithdrawalQueue
+        );
+
+        emit ETHDistributed(
+            _reportedData.reportTimestamp,
+            reportContext.preCLBalance,
+            _reportedData.postCLBalance,
+            withdrawals,
+            elRewards,
+            BUFFERED_ETHER_POSITION
+        );
+
+        if (reportContext.sharesToBurn > 0) {
+            IBurner(contracts.burner).commitSharesToBurn(reportContext.sharesToBurn);
+            _burnShares(contracts.burner, reportContext.sharesToBurn);
+        }
+
+        reportContext.sharesMintedAsFees = _processRewards(
+            reportContext,
+            _reportedData.postCLBalance,
+            withdrawals,
+            elRewards
+        );
+
+        uint256[] memory token_rebase_return_data = _completeTokenRebase(
+            _reportedData,
+            reportContext,
+            IPostTokenRebaseReceiver(contracts.postTokenRebaseReceiver)
+        );
+        
+        uint256 postTotalShares = token_rebase_return_data[0];
+        uint256 postTotalPooledEther = token_rebase_return_data[1];
+
+        if (_reportedData.withdrawalFinalizationBatches.length != 0) {
+            IOracleReportSanityChecker(contracts.oracleReportSanityChecker).checkSimulatedShareRate(
+                postTotalPooledEther,
+                postTotalShares,
+                reportContext.etherToLockOnWithdrawalQueue,
+                reportContext.sharesToBurn - reportContext.simulatedSharesToBurn,
+                _reportedData.simulatedShareRate
+            );
+        }
+
+        return [postTotalPooledEther, postTotalShares, withdrawals, elRewards];
+    }
+
+    function _checkAccountingOracleReport(
+        OracleReportContracts memory _contracts,
+        OracleReportedData memory _reportedData,
+        OracleReportContext memory _reportContext
+    ) internal {
+        IOracleReportSanityChecker(_contracts.oracleReportSanityChecker).checkAccountingOracleReport(
+            _reportedData.timeElapsed,
+            _reportContext.preCLBalance,
+            _reportedData.postCLBalance,
+            _reportedData.withdrawalVaultBalance,
+            _reportedData.elRewardsVaultBalance,
+            _reportedData.sharesRequestedToBurn,
+            _reportContext.preCLValidators,
+            _reportedData.clValidators
+        );
+    }
+
+ 
+    function _completeTokenRebase(
+        OracleReportedData memory _reportedData,
+        OracleReportContext memory _reportContext,
+        IPostTokenRebaseReceiver _postTokenRebaseReceiver
+    ) internal returns (uint256[] memory return_data) {
+        return_data = new uint256[](2);
+
+        uint256 postTotalShares = _getTotalShares();
+        uint256 postTotalPooledEther = _getTotalPooledEther();
+        
+        return_data[0] = postTotalShares;
+        return_data[1] = postTotalPooledEther;
+        
+        if (address(_postTokenRebaseReceiver) != address(0)) {
+            _postTokenRebaseReceiver.handlePostTokenRebase(
+                _reportedData.reportTimestamp,
+                _reportedData.timeElapsed,
+                _reportContext.preTotalShares,
+                _reportContext.preTotalPooledEther,
+                postTotalShares,
+                postTotalPooledEther,
+                _reportContext.sharesMintedAsFees
+            );
+        }
+
+        emit TokenRebased(
+            _reportedData.reportTimestamp,
+            _reportedData.timeElapsed,
+            _reportContext.preTotalShares,
+            _reportContext.preTotalPooledEther,
+            postTotalShares,
+            postTotalPooledEther,
+            _reportContext.sharesMintedAsFees
+        );
+    }
+
+    function _loadOracleReportContracts() internal returns (OracleReportContracts memory ret) {
+        address[] memory oracle_report_components_return_data = getLidoLocator().oracleReportComponentsForLido();
+
+        ret.accountingOracle = oracle_report_components_return_data[0];
+        ret.elRewardsVault = oracle_report_components_return_data[1];
+        ret.oracleReportSanityChecker = oracle_report_components_return_data[2];
+        ret.burner = oracle_report_components_return_data[3];
+        ret.withdrawalQueue = oracle_report_components_return_data[4];
+        ret.withdrawalVault = oracle_report_components_return_data[5];
+        ret.postTokenRebaseReceiver = oracle_report_components_return_data[6];
+         
+    }
+
+    function _stakingRouter() internal returns (IStakingRouter) {
+        return IStakingRouter(getLidoLocator().stakingRouter());
+    }
+
+    function _withdrawalQueue() internal returns (IWithdrawalQueue) {
+        return IWithdrawalQueue(getLidoLocator().withdrawalQueue());
+    }
+
+    function _treasury() internal returns (address) {
+        return getLidoLocator().treasury();
+    }
+
+    /*stETH methods start*/
+
+    function name() external returns (string memory) {
+        return "Liquid staked Ether 2.0";
+    }
+
+ 
+    function symbol() external returns (string memory) {
+        return "stETH";
+    }
+
+    function decimals() external returns (uint8) {
+        return 18;
+    }
+
+    function totalSupply() external returns (uint256) {
+        return _getTotalPooledEther();
+    }
+
+    function getTotalPooledEther() external returns (uint256) {
+        return _getTotalPooledEther();
+    }
+
+
+    function balanceOf(address _account) external returns (uint256) {
+        return getPooledEthByShares(_sharesOf(_account));
+    }
+
+    function transfer(address _recipient, uint256 _amount) external returns (bool) {
+        _transfer(msg.sender, _recipient, _amount);
+        return true;
+    }
+
+
+    function allowance(address _owner, address _spender) external returns (uint256) {
+        return allowances[_owner][_spender];
+    }
+
+ 
+    function approve(address _spender, uint256 _amount) external returns (bool) {
+        _approve(msg.sender, _spender, _amount);
+        return true;
+    }
+
+    function transferFrom(address _sender, address _recipient, uint256 _amount) external returns (bool) {
+        _spendAllowance(_sender, msg.sender, _amount);
+        _transfer(_sender, _recipient, _amount);
+        return true;
+    }
+
+    function getTotalShares() external returns (uint256) {
+        return _getTotalShares();
+    }
+  
+    function sharesOf(address _account) external returns (uint256) {
+        return _sharesOf(_account);
+    }
+
+    function getSharesByPooledEth(uint256 _ethAmount) public returns (uint256) {
+        return _ethAmount * _getTotalShares() / _getTotalPooledEther();
+    }
+    function getPooledEthByShares(uint256 _sharesAmount) public returns (uint256) {
+        return _sharesAmount * _getTotalPooledEther() / _getTotalShares();
+    }
+
+
+    function transferShares(address _recipient, uint256 _sharesAmount) external returns (uint256) {
+        _transferShares(msg.sender, _recipient, _sharesAmount);
+        uint256 tokensAmount = getPooledEthByShares(_sharesAmount);
+        _emitTransferEvents(msg.sender, _recipient, tokensAmount, _sharesAmount);
+        return tokensAmount;
+    }
+
+    function transferSharesFrom(
+        address _sender, address _recipient, uint256 _sharesAmount
+    ) external returns (uint256) {
+        uint256 tokensAmount = getPooledEthByShares(_sharesAmount);
+        _spendAllowance(_sender, msg.sender, tokensAmount);
+        _transferShares(_sender, _recipient, _sharesAmount);
+        _emitTransferEvents(_sender, _recipient, tokensAmount, _sharesAmount);
+        return tokensAmount;
+    }
+
+    function _transfer(address _sender, address _recipient, uint256 _amount) internal {
+        uint256 _sharesToTransfer = getSharesByPooledEth(_amount);
+        _transferShares(_sender, _recipient, _sharesToTransfer);
+        _emitTransferEvents(_sender, _recipient, _amount, _sharesToTransfer);
+    }
+
+
+    function _approve(address _owner, address _spender, uint256 _amount) internal {
+        require(_owner != address(0), "APPROVE_FROM_ZERO_ADDR");
+        require(_spender != address(0), "APPROVE_TO_ZERO_ADDR");
+
+        allowances[_owner][_spender] = _amount;
+        emit Approval(_owner, _spender, _amount);
+    }
+
+    function _spendAllowance(address _owner, address _spender, uint256 _amount) internal {
+        uint256 currentAllowance = allowances[_owner][_spender];
+        if (currentAllowance != INFINITE_ALLOWANCE) {
+            require(currentAllowance >= _amount, "ALLOWANCE_EXCEEDED");
+            _approve(_owner, _spender, currentAllowance - _amount);
+        }
+    }
+
+    function _getTotalShares() internal returns (uint256) {
+        return TOTAL_SHARES_POSITION;
+    }
+
+    function _sharesOf(address _account) internal returns (uint256) {
+        return shares[_account];
+    }
+
+    function _transferShares(address _sender, address _recipient, uint256 _sharesAmount) internal {
+        require(_sender != address(0), "TRANSFER_FROM_ZERO_ADDR");
+        require(_recipient != address(0), "TRANSFER_TO_ZERO_ADDR");
+        require(_recipient != address(this), "TRANSFER_TO_STETH_CONTRACT");
+
+        uint256 currentSenderShares = shares[_sender];
+        require(_sharesAmount <= currentSenderShares, "BALANCE_EXCEEDED");
+
+        shares[_sender] = currentSenderShares - _sharesAmount;
+        shares[_recipient] = shares[_recipient] + _sharesAmount;
+    }
+
+    function _mintShares(address _recipient, uint256 _sharesAmount) internal returns (uint256 newTotalShares) {
+        require(_recipient != address(0), "MINT_TO_ZERO_ADDR");
+
+        newTotalShares = _getTotalShares() + _sharesAmount;
+        TOTAL_SHARES_POSITION = newTotalShares;
+
+        shares[_recipient] = shares[_recipient] + _sharesAmount;
+
+    }
+
+    function _burnShares(address _account, uint256 _sharesAmount) internal returns (uint256 newTotalShares) {
+        require(_account != address(0), "BURN_FROM_ZERO_ADDR");
+
+        uint256 accountShares = shares[_account];
+        require(_sharesAmount <= accountShares, "BALANCE_EXCEEDED");
+
+        uint256 preRebaseTokenAmount = getPooledEthByShares(_sharesAmount);
+
+        newTotalShares = _getTotalShares() - _sharesAmount;
+        TOTAL_SHARES_POSITION = newTotalShares;
+
+        shares[_account] = accountShares - _sharesAmount;
+
+        uint256 postRebaseTokenAmount = getPooledEthByShares(_sharesAmount);
+
+        emit SharesBurnt(_account, preRebaseTokenAmount, postRebaseTokenAmount, _sharesAmount);
+
+    }
+
+ 
+    function _emitTransferEvents(address _from, address _to, uint _tokenAmount, uint256 _sharesAmount) internal {
+        emit Transfer(_from, _to, _tokenAmount);
+        emit TransferShares(_from, _to, _sharesAmount);
+    }
+
+
+    function _emitTransferAfterMintingShares(address _to, uint256 _sharesAmount) internal {
+        _emitTransferEvents(address(0), _to, getPooledEthByShares(_sharesAmount), _sharesAmount);
+    }
+
+    function _mintInitialShares(uint256 _sharesAmount) internal {
+        _mintShares(INITIAL_TOKEN_HOLDER, _sharesAmount);
+        _emitTransferAfterMintingShares(INITIAL_TOKEN_HOLDER, _sharesAmount);
+    }
+    
+    /*stETH methods end*/
+
+}
+

--- a/solidity-lite-syntax/examples/staking/LiquidStaking.sol
+++ b/solidity-lite-syntax/examples/staking/LiquidStaking.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// The source code of this contract uses the following contracts
+// LiquidStaking: https://github.com/harsh08881/liquidstaking/blob/main/liquidstack.sol
+
+interface IERC20 {
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(address from, address to, uint value) external returns (bool);
+}
+
+
+contract LiquidStaking {
+    IERC20 public stakingToken;
+    IERC20 public rewardToken;
+
+    mapping(address => uint256) public stakedBalances;
+    mapping(address => uint256) public stakedTimestamps;
+
+    uint256 public stakingDuration = 30 days;
+
+    constructor(address _stakingToken, address _rewardToken) {
+        stakingToken = IERC20(_stakingToken);
+        rewardToken = IERC20(_rewardToken);
+    }
+
+    function stake(uint256 amount) external {
+        require(amount > 0, "Amount must be greater than 0");
+
+        require(stakingToken.transferFrom(msg.sender, address(this), amount), "Token transfer failed");
+
+        stakedBalances[msg.sender] += amount;
+        stakedTimestamps[msg.sender] = block.timestamp;
+    }
+
+    function unstake() external {
+        uint256 stakedAmount = stakedBalances[msg.sender];
+        require(stakedAmount > 0, "No tokens staked");
+
+        require(block.timestamp >= stakedTimestamps[msg.sender] + stakingDuration, "Staking period not over");
+
+        uint256 rewards = calculateRewards(msg.sender);
+
+        require(stakingToken.transfer(msg.sender, stakedAmount), "Token transfer failed");
+        require(rewardToken.transfer(msg.sender, rewards), "Reward transfer failed");
+
+        stakedBalances[msg.sender] = 0;
+        stakedTimestamps[msg.sender] = 0;
+    }
+
+    function calculateRewards(address user) internal returns (uint256) {
+        uint256 stakedAmount = stakedBalances[user];
+        uint256 stakingTime = block.timestamp - stakedTimestamps[user];
+
+        uint256 annualInterestRate = 7;
+        uint256 secondsInYear = 365 days;
+        uint256 rewardRate = annualInterestRate * stakingTime / secondsInYear;
+
+        uint256 rewards = (stakedAmount * rewardRate) / 100; 
+
+        return rewards;
+    }
+}

--- a/solidity-lite-syntax/examples/swaps/UniswapV2Swap.sol
+++ b/solidity-lite-syntax/examples/swaps/UniswapV2Swap.sol
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: MIT
+
+// The source code of this contract uses the following contracts
+// UniswapV2SwapExamples: https://solidity-by-example.org/defi/uniswap-v2/
+// For the Router: https://github.com/Uniswap/v2-periphery/blob/master/contracts/UniswapV2Router02.sol
+// For the Pairs: https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2Pair.sol
+
+pragma solidity ^0.8.24;
+
+interface IERC20 {
+    function balanceOf(address owner) external returns (uint);
+    function transfer(address to, uint value) external returns (bool);
+    function transferFrom(address from, address to, uint value) external returns (bool);
+    function approve(address spender, uint256 value) external returns (bool);
+}
+
+contract UniswapV2Swap {
+
+    IERC20 public weth;
+    IERC20 public dai;
+    IERC20 public usdc;
+    UniswapV2Router02 public router;
+
+    constructor(address _weth, address _dai, address _usdc){
+        weth = IERC20(_weth);
+        dai = IERC20(_dai);
+        usdc = IERC20(_usdc);
+        router = new UniswapV2Router02();
+        router.set_local_pair(_weth, _dai);
+        router.set_local_pair(_weth, _usdc);
+        router.set_local_pair(_usdc, _dai);
+    }
+
+    function swapSingleHopExactAmountIn(uint256 amountIn, uint256 amountOutMin)
+        external
+        returns (uint256 amountOut)
+    {
+        weth.transferFrom(msg.sender, address(this), amountIn);
+        weth.approve(address(router), amountIn);
+
+        address[] memory path;
+        path = new address[](2);
+        path[0] = address(weth);
+        path[1] = address(dai);
+
+        uint256[] memory amounts = router.swapExactTokensForTokens(amountIn, amountOutMin, path, msg.sender);
+
+        return amounts[1];
+    }
+
+    function swapMultiHopExactAmountIn(uint256 amountIn, uint256 amountOutMin)
+        external
+        returns (uint256 amountOut)
+    {
+        dai.transferFrom(msg.sender, address(this), amountIn);
+        dai.approve(address(router), amountIn);
+
+        address[] memory path;
+        path = new address[](3);
+        path[0] = address(dai);
+        path[1] = address(weth);
+        path[2] = address(usdc);
+
+        uint256[] memory amounts = router.swapExactTokensForTokens(amountIn, amountOutMin, path, msg.sender);
+
+        return amounts[2];
+    }
+
+    function swapSingleHopExactAmountOut(
+        uint256 amountOutDesired,
+        uint256 amountInMax
+    ) external returns (uint256 amountOut) {
+        weth.transferFrom(msg.sender, address(this), amountInMax);
+        weth.approve(address(router), amountInMax);
+
+        address[] memory path;
+        path = new address[](2);
+        path[0] = address(weth);
+        path[1] = address(dai);
+
+        uint256[] memory amounts = router.swapTokensForExactTokens(amountOutDesired, amountInMax, path, msg.sender);
+
+        if (amounts[0] < amountInMax) {
+            weth.transfer(msg.sender, amountInMax - amounts[0]);
+        }
+
+        return amounts[1];
+    }
+
+    function swapMultiHopExactAmountOut(
+        uint256 amountOutDesired,
+        uint256 amountInMax
+    ) external returns (uint256 amountOut) {
+        dai.transferFrom(msg.sender, address(this), amountInMax);
+        dai.approve(address(router), amountInMax);
+
+        address[] memory path;
+        path = new address[](3);
+        path[0] = address(dai);
+        path[1] = address(weth);
+        path[2] = address(usdc);
+
+        uint256[] memory amounts = router.swapTokensForExactTokens(amountOutDesired, amountInMax, path, msg.sender);
+
+        if (amounts[0] < amountInMax) {
+            dai.transfer(msg.sender, amountInMax - amounts[0]);
+        }
+
+        return amounts[2];
+    }
+}
+
+contract UniswapV2Router02 {
+
+    mapping (address => mapping (address => address)) public local_pairs;
+
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to
+    ) external returns (uint[] memory amounts) {
+        amounts = uniswapV2Library_getAmountsOut(amountIn, path);
+        require(amounts[amounts.length - 1] >= amountOutMin, "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT");
+        IERC20(path[0]).transferFrom(msg.sender, uniswapV2Library_pairFor(path[0], path[1]), amounts[0]);
+        _swap(amounts, path, to);
+    }
+
+    function swapTokensForExactTokens(
+        uint amountOut,
+        uint amountInMax,
+        address[] calldata path,
+        address to
+    ) external returns (uint[] memory amounts) {
+        amounts = uniswapV2Library_getAmountsIn(amountOut, path);
+        require(amounts[0] <= amountInMax, "UniswapV2Router: EXCESSIVE_INPUT_AMOUNT");
+        IERC20(path[0]).transferFrom(msg.sender, uniswapV2Library_pairFor(path[0], path[1]), amounts[0]);
+        _swap(amounts, path, to);
+    }
+
+    function set_local_pair(address tokenA, address tokenB) public{
+        address[] memory tokens = uniswapV2Library_sortTokens(tokenA, tokenB);
+        local_pairs[tokens[0]][tokens[1]] = address(new UniswapV2Pair(address(tokens[0]), address(tokens[1])));
+    }
+
+    function get_local_pair(address tokenA, address tokenB) public returns(address pair){
+        address[] memory tokens = uniswapV2Library_sortTokens(tokenA, tokenB);
+        pair = local_pairs[tokens[0]][tokens[1]];
+    }
+
+    function sync_local_pair(address tokenA, address tokenB) public{
+        address[] memory tokens = uniswapV2Library_sortTokens(tokenA, tokenB);
+        UniswapV2Pair(local_pairs[tokens[0]][tokens[1]]).sync();
+    }
+
+    function _swap(uint[] memory amounts, address[] memory path, address _to) internal virtual {
+        for (uint i; i < path.length - 1; i++) {
+            address input = path[i];
+            address output = path[i + 1];
+            address[] memory tokens = uniswapV2Library_sortTokens(input, output);
+            uint amountOut = amounts[i + 1];
+            
+            uint amount0Out = input == tokens[0] ? uint(0) : amountOut;
+            uint amount1Out = input == tokens[0] ? amountOut : uint(0);
+            address to = i < path.length - 2 ? uniswapV2Library_pairFor(output, path[i + 2]) : _to;
+            UniswapV2Pair(uniswapV2Library_pairFor(input, output)).swap(
+                amount0Out, amount1Out, to);
+        }
+    }
+
+    function uniswapV2Library_pairFor(address tokenA, address tokenB) internal returns (address pair) {
+        address[] memory tokens = uniswapV2Library_sortTokens(tokenA, tokenB);
+        pair = local_pairs[tokens[0]][tokens[1]];
+    }
+
+    function uniswapV2Library_sortTokens(address tokenA, address tokenB) internal returns (address[] memory tokens) {
+        tokens = new address[](2);
+        require(tokenA != tokenB, "UniswapV2Library: IDENTICAL_ADDRESSES");
+        tokens[0] = tokenA < tokenB ? tokenA : tokenB;
+        tokens[1] = tokenA < tokenB ? tokenB : tokenA;
+        require(tokens[0] != address(0), "UniswapV2Library: ZERO_ADDRESS");
+    }
+
+    function uniswapV2Library_getAmountsOut(uint amountIn, address[] memory path) internal returns (uint[] memory amounts) {
+        require(path.length >= 2, "UniswapV2Library: INVALID_PATH");
+        amounts = new uint[](path.length);
+        amounts[0] = amountIn;
+        for (uint i; i < path.length - 1; i++) {
+            uint[] memory reserves = uniswapV2Library_getReserves(path[i], path[i + 1]);
+            amounts[i + 1] = uniswapV2Library_getAmountOut(amounts[i], reserves[0], reserves[1]);
+        }
+    }
+
+    function uniswapV2Library_getAmountOut(uint amountIn, uint reserveIn, uint reserveOut) internal returns (uint amountOut) {
+        require(amountIn > 0, "UniswapV2Library: INSUFFICIENT_INPUT_AMOUNT");
+        require(reserveIn > 0 && reserveOut > 0, "UniswapV2Library: INSUFFICIENT_LIQUIDITY");
+        uint amountInWithFee = amountIn*997;
+        uint numerator = amountInWithFee*reserveOut;
+        uint denominator = reserveIn*1000 + amountInWithFee;
+        amountOut = numerator / denominator;
+    }
+
+    function uniswapV2Library_getReserves(address tokenA, address tokenB) internal returns (uint[] memory reserves) {
+        reserves = new uint[](2);
+        address[] memory tokens = uniswapV2Library_sortTokens(tokenA, tokenB);
+        uint112[] memory pair_reserves = UniswapV2Pair(uniswapV2Library_pairFor(tokenA, tokenB)).getReserves();
+        reserves[0] = tokenA == tokens[0] ? pair_reserves[0] : pair_reserves[1];
+        reserves[1] = tokenA == tokens[0] ? pair_reserves[1] : pair_reserves[0];
+    }
+    
+    function uniswapV2Library_getAmountsIn(uint amountOut, address[] memory path) internal returns (uint[] memory amounts) {
+        require(path.length >= 2, "UniswapV2Library: INVALID_PATH");
+        amounts = new uint[](path.length);
+        amounts[amounts.length - 1] = amountOut;
+        for (uint i = path.length - 1; i > 0; i--) {
+            uint[] memory reserves = uniswapV2Library_getReserves(path[i - 1], path[i]);
+            amounts[i - 1] = uniswapV2Library_getAmountIn(amounts[i], reserves[0], reserves[1]);
+        }
+    }
+
+    function uniswapV2Library_getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) internal returns (uint amountIn) {
+        require(amountOut > 0, "UniswapV2Library: INSUFFICIENT_OUTPUT_AMOUNT");
+        require(reserveIn > 0 && reserveOut > 0, "UniswapV2Library: INSUFFICIENT_LIQUIDITY");
+        uint numerator = reserveIn*amountOut*1000;
+        uint denominator = (reserveOut-amountOut)*997;
+        amountIn = denominator != 0 ? (numerator / denominator) + 1 : 1;
+    }
+}
+
+contract UniswapV2Pair{
+
+    address public token0;
+    address public token1;
+
+    uint112 private reserve0;           
+    uint112 private reserve1;           
+    uint32  private blockTimestampLast; 
+
+    uint public MINIMUM_LIQUIDITY = 10**3;
+    uint public price0CumulativeLast;
+    uint public price1CumulativeLast;
+    uint public totalSupply;
+    uint public kLast; 
+    
+    mapping(address => uint) public balanceOf;
+    
+    event Sync(uint112 reserve0, uint112 reserve1);
+    event Swap(
+        address indexed sender,
+        uint amount0In,
+        uint amount1In,
+        uint amount0Out,
+        uint amount1Out,
+        address indexed to
+    );
+
+    constructor(address _token0, address _token1) {
+        token0 = _token0;
+        token1 = _token1;
+    }
+
+    function swap(uint amount0Out, uint amount1Out, address to) external {
+        require(amount0Out > 0 || amount1Out > 0, "UniswapV2: INSUFFICIENT_OUTPUT_AMOUNT");
+        uint112[] memory reserves = getReserves(); // gas savings
+        require(amount0Out < reserves[0] && amount1Out < reserves[1], "UniswapV2: INSUFFICIENT_LIQUIDITY");
+
+        uint balance0;
+        uint balance1;
+        { // scope for _token{0,1}, avoids stack too deep errors
+            address _token0 = token0;
+            address _token1 = token1;
+            require(to != _token0 && to != _token1, "UniswapV2: INVALID_TO");
+            if (amount0Out > 0) IERC20(_token0).transfer(to, amount0Out); // optimistically transfer tokens
+            if (amount1Out > 0) IERC20(_token1).transfer(to, amount1Out); // optimistically transfer tokens
+            balance0 = IERC20(_token0).balanceOf(address(this));
+            balance1 = IERC20(_token1).balanceOf(address(this));
+        }
+        uint amount0In = balance0 > reserves[0] - amount0Out ? balance0 - (reserves[0] - amount0Out) : 0;
+        uint amount1In = balance1 > reserves[1] - amount1Out ? balance1 - (reserves[1] - amount1Out) : 0;
+        require(amount0In > 0 || amount1In > 0, "UniswapV2: INSUFFICIENT_INPUT_AMOUNT");
+        { // scope for reserve{0,1}Adjusted, avoids stack too deep errors
+            uint balance0Adjusted = (balance0*1000)-(amount0In*3);
+            uint balance1Adjusted = (balance1*1000)-(amount1In*3);
+            require(balance0Adjusted*balance1Adjusted >= uint(reserves[0])*reserves[1]*(1000**2), "UniswapV2: K");
+        }
+
+        _update(balance0, balance1, reserves[0], reserves[1]);
+        emit Swap(msg.sender, amount0In, amount1In, amount0Out, amount1Out, to);
+    }
+
+    function sync() external {
+        _update(IERC20(token0).balanceOf(address(this)), IERC20(token1).balanceOf(address(this)), reserve0, reserve1);
+    }
+   
+    function getReserves() public returns (uint112[] memory reserves) {
+        reserves = new uint112[](3);
+        reserves[0] = reserve0;
+        reserves[1] = reserve1;
+        reserves[2] = blockTimestampLast;
+    }
+
+    function _update(uint balance0, uint balance1, uint112 _reserve0, uint112 _reserve1) private {
+        require(balance0 <= type(uint112).max && balance1 <= type(uint112).max, "UniswapV2: OVERFLOW");
+        uint32 blockTimestamp = uint32(block.timestamp % 2**32);
+        uint32 timeElapsed = blockTimestamp - blockTimestampLast; // overflow is desired
+        if (timeElapsed > 0 && _reserve0 != 0 && _reserve1 != 0) {
+            price0CumulativeLast += (_reserve1/_reserve0) * timeElapsed;
+            price1CumulativeLast += (_reserve0/_reserve1) * timeElapsed;
+        }
+        reserve0 = uint112(balance0);
+        reserve1 = uint112(balance1);
+        blockTimestampLast = blockTimestamp;
+        emit Sync(reserve0, reserve1);
+    } 
+}

--- a/solidity-lite-syntax/examples/tokens/SomeMultiToken.sol
+++ b/solidity-lite-syntax/examples/tokens/SomeMultiToken.sol
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+// Compatible with OpenZeppelin Contracts ^5.0.0
+
+
+// The source code of this contract uses the following OpenZeppelin contracts
+// ERC1155: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC1155/ERC1155.sol
+pragma solidity ^0.8.20;
+
+contract SomeMultiToken{
+    
+    uint256 public GOLD = 0;
+    uint256 public SILVER = 1;
+    
+    string private _uri;
+
+    mapping(uint256 id => mapping(address account => uint256)) private _balances;
+    mapping(address account => mapping(address operator => bool)) private _operatorApprovals;
+
+    event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value);
+    event TransferBatch(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256[] ids,
+        uint256[] values
+    );
+    event ApprovalForAll(address indexed account, address indexed operator, bool approved);
+    event URI(string value, uint256 indexed id);
+
+    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);
+    error ERC1155InvalidSender(address sender);
+    error ERC1155InvalidReceiver(address receiver);
+    error ERC1155MissingApprovalForAll(address operator, address owner);
+    error ERC1155InvalidApprover(address approver);
+    error ERC1155InvalidOperator(address operator);
+    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);
+
+    constructor(string memory uri_, uint256 init_supply) {
+        _setURI(uri_);
+        _mint(msg.sender, GOLD, init_supply);
+        _mint(msg.sender, SILVER, init_supply);
+    }
+
+    function balanceOf(address account, uint256 id) public returns (uint256) {
+        return _balances[id][account];
+    }
+
+    function balanceOfBatch(
+        address[] memory accounts,
+        uint256[] memory ids
+    ) public returns (uint256[] memory) {
+        if (accounts.length != ids.length) {
+            revert ERC1155InvalidArrayLength(ids.length, accounts.length);
+        }
+
+        uint256[] memory batchBalances = new uint256[](accounts.length);
+
+        for (uint256 i = 0; i < accounts.length; ++i) {
+            batchBalances[i] = balanceOf(accounts[i], ids[i]);
+        }
+
+        return batchBalances;
+    }
+
+    function setApprovalForAll(address operator, bool approved) public {
+        _setApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function isApprovedForAll(address account, address operator) public returns (bool) {
+        return _operatorApprovals[account][operator];
+    }
+
+    function safeTransferFrom(address from, address to, uint256 id, uint256 value) public {
+        address sender = msg.sender;
+        if (from != sender && !isApprovedForAll(from, sender)) {
+            revert ERC1155MissingApprovalForAll(sender, from);
+        }
+        _safeTransferFrom(from, to, id, value);
+    }
+
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values
+    ) public {
+        address sender = msg.sender;
+        if (from != sender && !isApprovedForAll(from, sender)) {
+            revert ERC1155MissingApprovalForAll(sender, from);
+        }
+        _safeBatchTransferFrom(from, to, ids, values);
+    }
+
+    function _update(address from, address to, uint256[] memory ids, uint256[] memory values) internal {
+        if (ids.length != values.length) {
+            revert ERC1155InvalidArrayLength(ids.length, values.length);
+        }
+
+        address operator = msg.sender;
+
+        for (uint256 i = 0; i < ids.length; ++i) {
+            uint256 id = ids[i];
+            uint256 value = values[i];
+
+            if (from != address(0)) {
+                uint256 fromBalance = _balances[id][from];
+                if (fromBalance < value) {
+                    revert ERC1155InsufficientBalance(from, fromBalance, value, id);
+                }
+                _balances[id][from] = fromBalance - value;
+                
+            }
+
+            if (to != address(0)) {
+                _balances[id][to] += value;
+            }
+        }
+
+        if (ids.length == 1) {
+            uint256 id = ids[0];
+            uint256 value = values[0];
+            emit TransferSingle(operator, from, to, id, value);
+        } else {
+            emit TransferBatch(operator, from, to, ids, values);
+        }
+    }
+
+    function _updateWithoutAcceptanceCheck(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values
+    ) internal {
+        _update(from, to, ids, values);
+    }
+
+    function _safeTransferFrom(address from, address to, uint256 id, uint256 value) internal {
+        if (to == address(0)) {
+            revert ERC1155InvalidReceiver(address(0));
+        }
+        if (from == address(0)) {
+            revert ERC1155InvalidSender(address(0));
+        }
+
+        uint256[] memory ids = new uint256[](1);
+        uint256[] memory values = new uint256[](1);
+
+        ids[0] = id;
+        values[0] = value;
+
+        _updateWithoutAcceptanceCheck(from, to, ids, values);
+    }
+
+    function _safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values
+    ) internal {
+        if (to == address(0)) {
+            revert ERC1155InvalidReceiver(address(0));
+        }
+        if (from == address(0)) {
+            revert ERC1155InvalidSender(address(0));
+        }
+        _updateWithoutAcceptanceCheck(from, to, ids, values);
+    }
+
+    function _setURI(string memory newuri) internal {
+        _uri = newuri;
+    }
+
+
+    function _mint(address to, uint256 id, uint256 value) internal {
+        if (to == address(0)) {
+            revert ERC1155InvalidReceiver(address(0));
+        }
+        
+        uint256[] memory ids = new uint256[](1);
+        uint256[] memory values = new uint256[](1);
+
+        ids[0] = id;
+        values[0] = value;
+
+        _updateWithoutAcceptanceCheck(address(0), to, ids, values);
+    }
+
+
+    function _mintBatch(address to, uint256[] memory ids, uint256[] memory values) internal {
+        if (to == address(0)) {
+            revert ERC1155InvalidReceiver(address(0));
+        }
+        _updateWithoutAcceptanceCheck(address(0), to, ids, values);
+    }
+
+
+    function _burn(address from, uint256 id, uint256 value) internal {
+        if (from == address(0)) {
+            revert ERC1155InvalidSender(address(0));
+        }
+        
+        uint256[] memory ids = new uint256[](1);
+        uint256[] memory values = new uint256[](1);
+
+        ids[0] = id;
+        values[0] = value;
+        
+        _updateWithoutAcceptanceCheck(from, address(0), ids, values);
+    }
+
+    function _burnBatch(address from, uint256[] memory ids, uint256[] memory values) internal {
+        if (from == address(0)) {
+            revert ERC1155InvalidSender(address(0));
+        }
+        _updateWithoutAcceptanceCheck(from, address(0), ids, values);
+    }
+
+
+    function _setApprovalForAll(address owner, address operator, bool approved) internal {
+        if (operator == address(0)) {
+            revert ERC1155InvalidOperator(address(0));
+        }
+        _operatorApprovals[owner][operator] = approved;
+        emit ApprovalForAll(owner, operator, approved);
+    }
+
+}

--- a/solidity-lite-syntax/examples/tokens/SomeToken.sol
+++ b/solidity-lite-syntax/examples/tokens/SomeToken.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+// Compatible with OpenZeppelin Contracts ^5.0.0
+
+// The source code of this contract uses the following OpenZeppelin contracts
+// ERC20: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol
+pragma solidity ^0.8.20;
+
+contract SomeToken {
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+
+    mapping(address account => uint256) private _balances;
+    mapping(address account => mapping(address spender => uint256)) private _allowances;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);
+    error ERC20InvalidSender(address sender);
+    error ERC20InvalidReceiver(address receiver);
+    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
+    error ERC20InvalidApprover(address approver);
+    error ERC20InvalidSpender(address spender);
+
+    constructor(string memory name_, string memory symbol_, uint256 init_supply) {
+        _name = name_;
+        _symbol = symbol_;
+        _mint(msg.sender, init_supply);
+    }
+
+    function decimals() public returns (uint8) {
+        return 18;
+    }
+
+    function totalSupply() public returns (uint256) {
+        return _totalSupply;
+    }
+    
+    function name() public returns (string memory) {
+        return _name;
+    }
+
+    function symbol() public returns (string memory) {
+        return _symbol;
+    }
+
+    function balanceOf(address account) public returns (uint256) {
+        return _balances[account];
+    }
+
+    function transfer(address to, uint256 value) public returns (bool) {
+        address owner = msg.sender;
+        _transfer(owner, to, value);
+        return true;
+    }
+
+    function allowance(address owner, address spender) public returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 value) public returns (bool) {
+        address owner = msg.sender;
+        _approve(owner, spender, value, true);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) public returns (bool) {
+        address spender = msg.sender;
+        _spendAllowance(from, spender, value);
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        if (from == address(0)) {
+            revert ERC20InvalidSender(address(0));
+        }
+        if (to == address(0)) {
+            revert ERC20InvalidReceiver(address(0));
+        }
+        _update(from, to, value);
+    }
+
+    function _update(address from, address to, uint256 value) internal {
+        if (from == address(0)) {
+            _totalSupply += value;
+        } else {
+            uint256 fromBalance = _balances[from];
+            if (fromBalance < value) {
+                revert ERC20InsufficientBalance(from, fromBalance, value);
+            }
+            _balances[from] = fromBalance - value;
+            
+        }
+
+        if (to == address(0)) {
+            _totalSupply -= value; 
+        } else {
+            _balances[to] += value;
+        }
+
+        emit Transfer(from, to, value);
+    }
+
+    function _mint(address account, uint256 value) internal {
+        if (account == address(0)) {
+            revert ERC20InvalidReceiver(address(0));
+        }
+        _update(address(0), account, value);
+    }
+
+    function _burn(address account, uint256 value) internal {
+        if (account == address(0)) {
+            revert ERC20InvalidSender(address(0));
+        }
+        _update(account, address(0), value);
+    }
+
+    function _approve(address owner, address spender, uint256 value, bool emitEvent) internal {
+        if (owner == address(0)) {
+            revert ERC20InvalidApprover(address(0));
+        }
+        if (spender == address(0)) {
+            revert ERC20InvalidSpender(address(0));
+        }
+        _allowances[owner][spender] = value;
+        if (emitEvent) {
+            emit Approval(owner, spender, value);
+        }
+    }
+
+    function _spendAllowance(address owner, address spender, uint256 value) internal {
+        uint256 currentAllowance = allowance(owner, spender);
+        if (currentAllowance != type(uint256).max) {
+            if (currentAllowance < value) {
+                revert ERC20InsufficientAllowance(spender, currentAllowance, value);
+            }
+            _approve(owner, spender, currentAllowance - value, false);
+            
+        }
+    }
+
+}

--- a/solidity-lite-syntax/solidity-syntax.md
+++ b/solidity-lite-syntax/solidity-syntax.md
@@ -1,35 +1,77 @@
 # Parser Definition
 
-Following contains a subset of the [Solidity Language Grammar](https://docs.soliditylang.org/en/latest/grammar.html) that can be used to parse the example solidity program in `examples\UniswapV2Swap.sol`
+Following contains a subset of the [Solidity Language Grammar](https://docs.soliditylang.org/en/latest/grammar.html) that can be used to parse the example solidity programs in `examples\` folder.
 
 ```k
 module SOLIDITY-SYNTAX
+```
+
+## Imported Modules
+
+We use `bool`, `string` and `id` modules, `int`s are defined in a custom way due to the solidity decimal syntax, described via `Decimal` token below
+
+```k
     imports BOOL-SYNTAX
     imports STRING-SYNTAX
     imports ID-SYNTAX
+```
 
-    syntax PragmaDefinition ::= r"pragma ([^;]+)*;[\\s]*"                     [token]
-    syntax HexNumber ::= r"0x[A-Fa-f0-9]+"                                    [token]
-    syntax Decimal ::= r"(([0-9][_]?)+|([0-9][_]?)*[\\.]([0-9][_]?)+)([eE][\\-]?([0-9][_]?)+)?"    [token]
+## Tokens-keywords
+
+We use tokens for the `pragma` definition in the header, hexadecimal numbers used as address literals and `address()` casts and, decimal notation used by solidity.
+
+```k
+    syntax PragmaDefinition ::= r"pragma ([^;]+)*;[\\s]*"                                           [token]
+    syntax HexNumber ::= r"0x[A-Fa-f0-9]+"                                                          [token]
+    syntax Decimal ::= r"(([0-9][_]?)+|([0-9][_]?)*[\\.]([0-9][_]?)+)([eE][\\-]?([0-9][_]?)+)?"     [token]
 
     syntax ElementaryTypeName ::= "uint" | "uint256" | "address" | "bool"
     syntax DataLocation ::= "memory" | "storage" | "calldata"
     syntax SubDenom ::= "wei" | "gwei" | "ether" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "years"
+```
 
+## Literals
+
+Custom decimal number literals (as described above), built-in boolean and string literals are used. Subdenominators can also be appended to number literals to factor time, etc.
+
+```k
     syntax Literal ::= NumberLiteral | BoolLiteral | StringLiteral
-    syntax BoolLiteral ::= Bool
-    syntax StringLiteral ::= String
     syntax NumberLiteral ::= DecimalNumber | HexNumber
     syntax DecimalNumber ::= Decimal
+    syntax BoolLiteral ::= Bool
+    syntax StringLiteral ::= String
+
     syntax LiteralWithSubDenom ::= DecimalNumber SubDenom
 
+```
+
+## Types
+
+A type identifier can be either `ElementaryTypeName` (see above), a single `Id` or a period separated path, a mapping or an array type.
+
+```k
     syntax TypeName ::= ElementaryTypeName | IdentifierPath | MappingType | TypeName "[" Expression "]" | TypeName "[""]"
     syntax IdentifierPath ::= Id "." IdentifierPath | Id
     syntax MappingType ::= "mapping" "(" MappingKeyType OptionalIdentifier "=>" TypeName OptionalIdentifier ")"
     syntax MappingKeyType ::= ElementaryTypeName | IdentifierPath
     syntax OptionalIdentifier ::= Id | ""
 
+```
+
+## Root
+
+Parsing starts from `Program` rule. A program is a pragma definition followed by some `SourceUnit`s
+
+```k
     syntax Program ::= PragmaDefinition SourceUnits
+
+```
+
+## Top level source units
+
+A contract file consists of a series of contract definitions listed as follows.
+
+```k
 
     syntax SourceUnits ::= List{SourceUnit, ""}
     syntax SourceUnit ::= ContractDefinition
@@ -43,7 +85,17 @@ module SOLIDITY-SYNTAX
     syntax FunctionDefinition ::= "function" Id "(" ParameterList ")" FunctionSpecifiers ReturnSpecifier FunctionBody
     syntax InterfaceDefinition ::= "interface" Id "{" ContractBodyElements "}"
     syntax ErrorDefinition ::= "error" Id "(" ErrorParameters ")" ";"
+    syntax StructDefinition ::= "struct" Id "{" StructMembers "}"
+    syntax EnumDefinition ::= "enum" Id "{" IdentifierList "}"
 
+    syntax IdentifierList ::= List{Id, ","}
+```
+
+## Contract
+
+A contract is a series of contract body elements listed as follows.
+
+```k
     syntax ContractBodyElements ::= List{ContractBodyElement, ""}
     syntax ContractBodyElement ::= StateVariableDeclaration
                                  | ConstructorDefinition
@@ -55,25 +107,15 @@ module SOLIDITY-SYNTAX
 
     syntax StateVariableDeclaration ::= TypeName VisibilitySpecifier Id ";"
                                       | TypeName VisibilitySpecifier Id  "=" Expression ";"
-
     syntax ConstructorDefinition ::= "constructor" "(" ParameterList ")" Block
     syntax EventDefinition ::= "event" Id "(" EventParameters ")" ";"
-    syntax StructDefinition ::= "struct" Id "{" StructMembers "}"
-    syntax EnumDefinition ::= "enum" Id "{" IdentifierList "}"
+```
 
-    syntax EventParameters ::= List{EventParameter, ","}
-    syntax EventParameter ::= TypeName | TypeName "indexed" | TypeName Id | TypeName "indexed" Id
+## Function definition
 
-    syntax ErrorParameters ::= List{ErrorParameter, ","}
-    syntax ErrorParameter ::= TypeName | TypeName Id
+A Function definition contains a parameter list and some specifiers. Supported list of specifiers is provided below. There's no induced order of specifiers due to the grammar definition of solidity.
 
-    syntax StructMembers ::= List{StructMember, ""}
-    syntax StructMember ::= TypeName Id ";"
-
-    syntax IdentifierList ::= List{Id, ","}
-
-    syntax VisibilitySpecifier ::= "internal" | "external" | "private" | "public"
-
+```k
     syntax ParameterList ::= List{Parameter, ","}
     syntax Parameter ::= TypeName DataLocation Id | TypeName Id | TypeName DataLocation | TypeName
     syntax FunctionSpecifiers ::= List{FunctionSpecifier, ""}
@@ -81,6 +123,41 @@ module SOLIDITY-SYNTAX
     syntax ReturnSpecifier ::= "returns" "(" ParameterList ")" | ""
     syntax FunctionBody ::= Block | ";"
 
+    syntax VisibilitySpecifier ::= "internal" | "external" | "private" | "public"
+```
+
+## Error definition
+
+An error can be defined with a set of parameters separated with commas.
+
+```k
+    syntax ErrorParameters ::= List{ErrorParameter, ","}
+    syntax ErrorParameter ::= TypeName | TypeName Id
+```
+
+## Event definition
+
+An event can be defined with a set of parameters separated with commas, additionally each parameter can be annotated with "indexed" keyword.
+
+```k
+    syntax EventParameters ::= List{EventParameter, ","}
+    syntax EventParameter ::= TypeName | TypeName "indexed" | TypeName Id | TypeName "indexed" Id
+```
+
+## Struct definition
+
+A struct can be defined with a set of members (a special case of variable declaration) separated with semicolons.
+
+```k
+    syntax StructMembers ::= List{StructMember, ""}
+    syntax StructMember ::= TypeName Id ";"
+```
+
+## Block definition
+
+In each code block, various statments and nested blocks can be present.
+
+```k
     syntax Block ::= "{" Statements "}"
     syntax Statements ::= List{Statement, ""}
     syntax Statement ::= Block
@@ -91,7 +168,13 @@ module SOLIDITY-SYNTAX
                         | EmitStatement
                         | ReturnStatement
                         | RevertStatement
+```
 
+## Statements
+
+Following is a list of supported statements.
+
+```k
     syntax ExpressionStatement ::= Expression ";"
 
     syntax VariableDeclarationStatement ::= VariableDeclaration ";"
@@ -115,12 +198,28 @@ module SOLIDITY-SYNTAX
 
     syntax VariableDeclaration ::= TypeName Id
                                 | TypeName DataLocation Id
+```
 
+`CallArgumentList` keeps a list of arguments for function calls and such (`revert()`, `emit()`, etc.)
+
+```k
     syntax CallArgumentList ::= List{Expression, ","}
 
+```
+
+For this subset `KeyValue` pairs are only used preceding function argument lists for `payable` functions and such.
+
+```k
     syntax KeyValues ::= List{KeyValue, ","}
     syntax KeyValue ::= Id ":" Expression
 
+```
+
+## Expressions
+
+Following is a list of supported expressions. Operator precendences are taken from [here](https://docs.soliditylang.org/en/latest/cheatsheet.html).
+
+```k
     syntax Expression ::= Id | Literal | LiteralWithSubDenom | ElementaryTypeName
                         > "(" Expression ")" [bracket]
                         | "[" CallArgumentList "]"
@@ -160,6 +259,11 @@ module SOLIDITY-SYNTAX
 
 endmodule
 
+```
+
+A placeholder module that imports syntax module
+
+```k
 module SOLIDITY
   imports SOLIDITY-SYNTAX
 endmodule

--- a/solidity-lite-syntax/solidity-syntax.md
+++ b/solidity-lite-syntax/solidity-syntax.md
@@ -5,7 +5,6 @@ Following contains a subset of the [Solidity Language Grammar](https://docs.soli
 ```k
 module SOLIDITY-SYNTAX
     imports BOOL-SYNTAX
-    //imports INT-SYNTAX
     imports STRING-SYNTAX
     imports ID-SYNTAX
 

--- a/solidity-lite-syntax/solidity-syntax.md
+++ b/solidity-lite-syntax/solidity-syntax.md
@@ -1,0 +1,167 @@
+# Parser Definition
+
+Following contains a subset of the [Solidity Language Grammar](https://docs.soliditylang.org/en/latest/grammar.html) that can be used to parse the example solidity program in `examples\UniswapV2Swap.sol`
+
+```k
+module SOLIDITY-SYNTAX
+    imports BOOL-SYNTAX
+    //imports INT-SYNTAX
+    imports STRING-SYNTAX
+    imports ID-SYNTAX
+
+    syntax PragmaDefinition ::= r"pragma ([^;]+)*;[\\s]*"                     [token]
+    syntax HexNumber ::= r"0x[A-Fa-f0-9]+"                                    [token]
+    syntax Decimal ::= r"(([0-9][_]?)+|([0-9][_]?)*[\\.]([0-9][_]?)+)([eE][\\-]?([0-9][_]?)+)?"    [token]
+
+    syntax ElementaryTypeName ::= "uint" | "uint256" | "address" | "bool"
+    syntax DataLocation ::= "memory" | "storage" | "calldata"
+    syntax SubDenom ::= "wei" | "gwei" | "ether" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "years"
+
+    syntax Literal ::= NumberLiteral | BoolLiteral | StringLiteral
+    syntax BoolLiteral ::= Bool
+    syntax StringLiteral ::= String
+    syntax NumberLiteral ::= DecimalNumber | HexNumber
+    syntax DecimalNumber ::= Decimal
+    syntax LiteralWithSubDenom ::= DecimalNumber SubDenom
+
+    syntax TypeName ::= ElementaryTypeName | IdentifierPath | MappingType | TypeName "[" Expression "]" | TypeName "[""]"
+    syntax IdentifierPath ::= Id "." IdentifierPath | Id
+    syntax MappingType ::= "mapping" "(" MappingKeyType OptionalIdentifier "=>" TypeName OptionalIdentifier ")"
+    syntax MappingKeyType ::= ElementaryTypeName | IdentifierPath
+    syntax OptionalIdentifier ::= Id | ""
+
+    syntax Program ::= PragmaDefinition SourceUnits
+
+    syntax SourceUnits ::= List{SourceUnit, ""}
+    syntax SourceUnit ::= ContractDefinition
+                        | FunctionDefinition
+                        | InterfaceDefinition
+                        | ErrorDefinition
+                        | StructDefinition
+                        | EnumDefinition
+
+    syntax ContractDefinition ::= "contract" Id "{" ContractBodyElements "}"
+    syntax FunctionDefinition ::= "function" Id "(" ParameterList ")" FunctionSpecifiers ReturnSpecifier FunctionBody
+    syntax InterfaceDefinition ::= "interface" Id "{" ContractBodyElements "}"
+    syntax ErrorDefinition ::= "error" Id "(" ErrorParameters ")" ";"
+
+    syntax ContractBodyElements ::= List{ContractBodyElement, ""}
+    syntax ContractBodyElement ::= StateVariableDeclaration
+                                 | ConstructorDefinition
+                                 | FunctionDefinition
+                                 | EventDefinition
+                                 | ErrorDefinition
+                                 | StructDefinition
+                                 | EnumDefinition
+
+    syntax StateVariableDeclaration ::= TypeName VisibilitySpecifier Id ";"
+                                      | TypeName VisibilitySpecifier Id  "=" Expression ";"
+
+    syntax ConstructorDefinition ::= "constructor" "(" ParameterList ")" Block
+    syntax EventDefinition ::= "event" Id "(" EventParameters ")" ";"
+    syntax StructDefinition ::= "struct" Id "{" StructMembers "}"
+    syntax EnumDefinition ::= "enum" Id "{" IdentifierList "}"
+
+    syntax EventParameters ::= List{EventParameter, ","}
+    syntax EventParameter ::= TypeName | TypeName "indexed" | TypeName Id | TypeName "indexed" Id
+
+    syntax ErrorParameters ::= List{ErrorParameter, ","}
+    syntax ErrorParameter ::= TypeName | TypeName Id
+
+    syntax StructMembers ::= List{StructMember, ""}
+    syntax StructMember ::= TypeName Id ";"
+
+    syntax IdentifierList ::= List{Id, ","}
+
+    syntax VisibilitySpecifier ::= "internal" | "external" | "private" | "public"
+
+    syntax ParameterList ::= List{Parameter, ","}
+    syntax Parameter ::= TypeName DataLocation Id | TypeName Id | TypeName DataLocation | TypeName
+    syntax FunctionSpecifiers ::= List{FunctionSpecifier, ""}
+    syntax FunctionSpecifier ::= VisibilitySpecifier | "virtual" | "payable"
+    syntax ReturnSpecifier ::= "returns" "(" ParameterList ")" | ""
+    syntax FunctionBody ::= Block | ";"
+
+    syntax Block ::= "{" Statements "}"
+    syntax Statements ::= List{Statement, ""}
+    syntax Statement ::= Block
+                        | VariableDeclarationStatement
+                        | ExpressionStatement
+                        | IfStatement
+                        | ForStatement
+                        | EmitStatement
+                        | ReturnStatement
+                        | RevertStatement
+
+    syntax ExpressionStatement ::= Expression ";"
+
+    syntax VariableDeclarationStatement ::= VariableDeclaration ";"
+                                            | VariableDeclaration "=" Expression ";"
+
+    syntax IfStatement ::= "if" "(" Expression ")" Statement
+                         | "if" "(" Expression ")" Statement "else" Statement
+
+    syntax ForStatement ::= "for" "(" InitStatement ConditionStatement PostLoopStatement ")" Statement
+    syntax InitStatement ::= VariableDeclarationStatement | ExpressionStatement | ";"
+    syntax ConditionStatement ::= ExpressionStatement | ";"
+    syntax PostLoopStatement ::= Expression | ""
+
+    syntax EmitStatement ::= "emit" Expression "(" CallArgumentList ")" ";"
+
+    syntax ReturnStatement ::= "return" ";"
+                            | "return" Expression ";"
+
+    syntax RevertStatement ::= "revert" "(" CallArgumentList ")" ";"
+                             | "revert" Id "(" CallArgumentList ")" ";"
+
+    syntax VariableDeclaration ::= TypeName Id
+                                | TypeName DataLocation Id
+
+    syntax CallArgumentList ::= List{Expression, ","}
+
+    syntax KeyValues ::= List{KeyValue, ","}
+    syntax KeyValue ::= Id ":" Expression
+
+    syntax Expression ::= Id | Literal | LiteralWithSubDenom | ElementaryTypeName
+                        > "(" Expression ")" [bracket]
+                        | "[" CallArgumentList "]"
+                        | "new" TypeName "(" CallArgumentList ")"
+                        | Expression "++" | Expression "--"
+                        | Expression "[" Expression "]" | Expression "[""]"
+                        | Expression "." Id | Expression ".address"
+                        | Expression "{" KeyValues "}"
+                        | Expression "(" CallArgumentList ")"
+                        > "++" Expression | "--" Expression
+                        | "!" Expression
+                        > left: Expression "**" Expression
+                        > left:
+                              Expression "*" Expression
+                            | Expression "/" Expression
+                            | Expression "%" Expression
+                        > left:
+                              Expression "+" Expression
+                            | Expression "-" Expression
+                        > left:
+                              Expression "<" Expression
+                            | Expression "<=" Expression
+                            | Expression ">" Expression
+                            | Expression ">=" Expression
+                        > left:
+                              Expression "==" Expression
+                            | Expression "!=" Expression
+                        > left: Expression "&&" Expression
+                        > left: Expression "||" Expression
+                        > left:
+                            Expression "?" Expression ":" Expression
+                            | Expression "+=" Expression
+                            | Expression "-=" Expression
+                            | Expression "*=" Expression
+                            | Expression "/=" Expression
+                            | Expression "=" Expression
+
+endmodule
+
+module SOLIDITY
+  imports SOLIDITY-SYNTAX
+endmodule
+```


### PR DESCRIPTION
This PR contains a syntax module implementation to support all the solidity exxamples present in the [solidity-examples repository](https://github.com/Pi-Squared-Inc/pi2-examples)

Also contained, a makefile to test with each set of examples, via standart `kast` and by generating a `bison` parser.