### PR TITLE
Replace revert statements with require in tests

### DIFF
--- a/test/examples/lending/AaveLendingPool.sol
+++ b/test/examples/lending/AaveLendingPool.sol
@@ -658,15 +658,18 @@ contract AaveLendingPool {
         ReserveData storage reserve = reserves[_reserve];
         UserReserveData storage user = usersReserveData[_user][_reserve];
 
+        require(
+            _rateMode == InterestRateMode.VARIABLE ||
+                _rateMode == InterestRateMode.STABLE,
+            "Invalid borrow rate mode"
+        );
         if (_rateMode == InterestRateMode.STABLE) {
             user.stableBorrowRate = reserve.currentStableBorrowRate;
             user.lastVariableBorrowCumulativeIndex = 0;
-        } else if (_rateMode == InterestRateMode.VARIABLE) {
+        } else {
             user.stableBorrowRate = 0;
             user.lastVariableBorrowCumulativeIndex = reserve
                 .lastVariableBorrowCumulativeIndex;
-        } else {
-            revert("Invalid borrow rate mode");
         }
         user.principalBorrowBalance =
             user.principalBorrowBalance +
@@ -905,16 +908,19 @@ contract AaveLendingPool {
         uint256 newPrincipalAmount = _principalBalance +
             _balanceIncrease +
             _amountBorrowed;
+        require(
+           _newBorrowRateMode == InterestRateMode.VARIABLE ||
+               _newBorrowRateMode == InterestRateMode.STABLE,
+           "Invalid new borrow rate mode"
+        );
         if (_newBorrowRateMode == InterestRateMode.STABLE) {
             core_increaseTotalBorrowsStableAndUpdateAverageRate(
                 reserve,
                 newPrincipalAmount,
                 reserve.currentStableBorrowRate
             );
-        } else if (_newBorrowRateMode == InterestRateMode.VARIABLE) {
-            core_increaseTotalBorrowsVariable(reserve, newPrincipalAmount);
         } else {
-            revert("Invalid new borrow rate mode");
+            core_increaseTotalBorrowsVariable(reserve, newPrincipalAmount);
         }
     }
 

--- a/test/examples/swaps/UniswapV2Swap.sol
+++ b/test/examples/swaps/UniswapV2Swap.sol
@@ -463,21 +463,12 @@ contract USDCMock {
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);
 
-    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);
-    error ERC20InvalidSender(address sender);
-    error ERC20InvalidReceiver(address receiver);
-    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
-    error ERC20InvalidApprover(address approver);
-    error ERC20InvalidSpender(address spender);
-
     function decimals() external returns (uint8) {
         return 18;
     }
 
     function mint(address account, uint256 value) public {
-        if (account == address(0)) {
-            revert ERC20InvalidReceiver(address(0));
-        }
+        require(account != address(0), "USDC: invalid receiver");
         _update(address(0), account, value);
     }
 
@@ -509,12 +500,8 @@ contract USDCMock {
     }
 
     function _transfer(address from, address to, uint256 value) internal {
-        if (from == address(0)) {
-            revert ERC20InvalidSender(address(0));
-        }
-        if (to == address(0)) {
-            revert ERC20InvalidReceiver(address(0));
-        }
+        require(from != address(0), "USDC: invalid sender");
+        require(to != address(0), "USDC: invalid receiver");
         _update(from, to, value);
     }
 
@@ -523,9 +510,7 @@ contract USDCMock {
             _totalSupply += value;
         } else {
             uint256 fromBalance = _balances[from];
-            if (fromBalance < value) {
-                revert ERC20InsufficientBalance(from, fromBalance, value);
-            }
+            require(fromBalance >= value, "USDC: insufficient balance");
             _balances[from] = fromBalance - value;
             
         }
@@ -542,12 +527,8 @@ contract USDCMock {
 
 
     function _approve(address owner, address spender, uint256 value, bool emitEvent) internal {
-        if (owner == address(0)) {
-            revert ERC20InvalidApprover(address(0));
-        }
-        if (spender == address(0)) {
-            revert ERC20InvalidSpender(address(0));
-        }
+        require(owner != address(0), "USDC: invalid approver");
+        require(spender != address(0), "USDC: invalid spender");
         _allowances[owner][spender] = value;
         if (emitEvent) {
             emit Approval(owner, spender, value);
@@ -557,9 +538,7 @@ contract USDCMock {
     function _spendAllowance(address owner, address spender, uint256 value) internal {
         uint256 currentAllowance = allowance(owner, spender);
         if (currentAllowance != type(uint256).max) {
-            if (currentAllowance < value) {
-                revert ERC20InsufficientAllowance(spender, currentAllowance, value);
-            }
+            require(currentAllowance >= value, "USDC: insufficient allowance");
             _approve(owner, spender, currentAllowance - value, false);
             
         }

--- a/test/examples/tokens/SomeToken.sol
+++ b/test/examples/tokens/SomeToken.sol
@@ -18,13 +18,6 @@ contract SomeToken {
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);
 
-    error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);
-    error ERC20InvalidSender(address sender);
-    error ERC20InvalidReceiver(address receiver);
-    error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
-    error ERC20InvalidApprover(address approver);
-    error ERC20InvalidSpender(address spender);
-
     constructor(string memory name_, string memory symbol_, uint256 init_supply) {
         _name = name_;
         _symbol = symbol_;
@@ -75,12 +68,8 @@ contract SomeToken {
     }
 
     function _transfer(address from, address to, uint256 value) internal {
-        if (from == address(0)) {
-            revert ERC20InvalidSender(address(0));
-        }
-        if (to == address(0)) {
-            revert ERC20InvalidReceiver(address(0));
-        }
+        require(from != address(0), "SomeToken: invalid sender");
+        require(to != address(0), "SomeToken: invalid receiver");
         _update(from, to, value);
     }
 
@@ -89,9 +78,7 @@ contract SomeToken {
             _totalSupply += value;
         } else {
             uint256 fromBalance = _balances[from];
-            if (fromBalance < value) {
-                revert ERC20InsufficientBalance(from, fromBalance, value);
-            }
+            require(fromBalance >= value, "SomeToken: insufficient balance");
             _balances[from] = fromBalance - value;
             
         }
@@ -106,26 +93,18 @@ contract SomeToken {
     }
 
     function _mint(address account, uint256 value) internal {
-        if (account == address(0)) {
-            revert ERC20InvalidReceiver(address(0));
-        }
+        require(account != address(0), "SomeToken: invalid receiver");
         _update(address(0), account, value);
     }
 
     function _burn(address account, uint256 value) internal {
-        if (account == address(0)) {
-            revert ERC20InvalidSender(address(0));
-        }
+        require(account != address(0), "SomeToken: invalid sender");
         _update(account, address(0), value);
     }
 
     function _approve(address owner, address spender, uint256 value, bool emitEvent) internal {
-        if (owner == address(0)) {
-            revert ERC20InvalidApprover(address(0));
-        }
-        if (spender == address(0)) {
-            revert ERC20InvalidSpender(address(0));
-        }
+        require(owner != address(0), "SomeToken: invalid approver");
+        require(spender != address(0), "SomeToken: invalid spender");
         _allowances[owner][spender] = value;
         if (emitEvent) {
             emit Approval(owner, spender, value);
@@ -135,9 +114,7 @@ contract SomeToken {
     function _spendAllowance(address owner, address spender, uint256 value) internal {
         uint256 currentAllowance = allowance(owner, spender);
         if (currentAllowance != type(uint256).max) {
-            if (currentAllowance < value) {
-                revert ERC20InsufficientAllowance(spender, currentAllowance, value);
-            }
+            require(currentAllowance >= value, "SomeToken: insufficient allowance");
             _approve(owner, spender, currentAllowance - value, false);
             
         }


### PR DESCRIPTION
This PR modifies the tests, replacing the `revert` statements with equivalent `require`, and removing the error declarations.

Resolves #1746