### PR TITLE
Remove type funtion calls from tests

### DIFF
--- a/test/examples/lending/AaveLendingPool.sol
+++ b/test/examples/lending/AaveLendingPool.sol
@@ -138,6 +138,8 @@ contract AaveLendingPool {
 
     ILendingPoolAddressesProvider public addressesProvider;
 
+    uint256 internal UINT256_MAX = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+
     /* LendingPoolCore variables*/
     mapping(address => ReserveData) internal reserves;
     mapping(address => mapping(address => UserReserveData))
@@ -298,13 +300,13 @@ contract AaveLendingPool {
         );
 
         require(
-            _amount != type(uint256).max || msg.sender == _onBehalfOf,
+            _amount != UINT256_MAX || msg.sender == _onBehalfOf,
             "To repay on behalf of an user an explicit amount to repay is needed."
         );
 
         vars.paybackAmount = vars.compoundedBorrowBalance + vars.originationFee;
 
-        if (_amount != type(uint256).max && _amount < vars.paybackAmount) {
+        if (_amount != UINT256_MAX && _amount < vars.paybackAmount) {
             vars.paybackAmount = _amount;
         }
 
@@ -1173,7 +1175,7 @@ contract AaveLendingPool {
         uint256 totalFeesETH,
         uint256 liquidationThreshold
     ) internal returns (uint256) {
-        if (borrowBalanceETH == 0) return type(uint256).max;
+        if (borrowBalanceETH == 0) return UINT256_MAX;
 
         return
             ((collateralBalanceETH * liquidationThreshold) / 100) /

--- a/test/examples/lending/LendingPool.sol
+++ b/test/examples/lending/LendingPool.sol
@@ -70,6 +70,8 @@ contract LendingPool {
         bool supported;
     }
 
+    uint256 internal UINT256_MAX = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+
     uint256 internal MAX_PROTOCOL_FEE = 0.5e4; // 5%
     uint256 public PRECISION = 1e18; // 18 decimals precision
     uint256 public BPS = 1e5; // 5 decimals precision
@@ -163,7 +165,7 @@ contract LendingPool {
         _accrueInterest(token);
         uint256 userBorrowShare = userShares[msg.sender][token].borrow;
         uint256 shares = _toShares(vaults[token].totalBorrow, amount, true);
-        if (amount == type(uint256).max || shares > userBorrowShare) {
+        if (amount == UINT256_MAX || shares > userBorrowShare) {
             shares = userBorrowShare;
             amount = _toAmount(vaults[token].totalBorrow, shares, true);
         }

--- a/test/examples/staking/LidoStaking.sol
+++ b/test/examples/staking/LidoStaking.sol
@@ -121,7 +121,7 @@ contract Lido{
 
     /*stETH variables start*/
     address internal INITIAL_TOKEN_HOLDER = address(0xdead);
-    uint256 internal INFINITE_ALLOWANCE = type(uint256).max;
+    uint256 internal INFINITE_ALLOWANCE = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     mapping (address => uint256) private shares;
     mapping (address => mapping (address => uint256)) private allowances;
     uint256 internal TOTAL_SHARES_POSITION;

--- a/test/examples/swaps/UniswapV2Swap.sol
+++ b/test/examples/swaps/UniswapV2Swap.sol
@@ -229,6 +229,8 @@ contract UniswapV2Router02 {
 
 contract UniswapV2Pair{
 
+    uint112 internal UINT112_MAX = 0xffffffffffffffffffffffffffff;
+
     address public token0;
     address public token1;
 
@@ -300,7 +302,7 @@ contract UniswapV2Pair{
     }
 
     function _update(uint balance0, uint balance1, uint112 _reserve0, uint112 _reserve1) private {
-        require(balance0 <= type(uint112).max && balance1 <= type(uint112).max, "UniswapV2: OVERFLOW");
+        require(balance0 <= UINT112_MAX && balance1 <= UINT112_MAX, "UniswapV2: OVERFLOW");
         uint32 blockTimestamp = uint32(block.timestamp % 2**32);
         uint32 timeElapsed = blockTimestamp - blockTimestampLast; // overflow is desired
         if (timeElapsed > 0 && _reserve0 != 0 && _reserve1 != 0) {
@@ -315,6 +317,8 @@ contract UniswapV2Pair{
 }
 
 contract WETHMock {
+
+    uint256 internal UINT256_MAX = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
     mapping (address => uint256) public balanceOf;
     mapping (address => mapping (address => uint256)) public allowance;
@@ -362,7 +366,7 @@ contract WETHMock {
     function transferFrom(address from, address to, uint256 value) external returns (bool) {
         if (from != msg.sender) {
             uint256 allowed = allowance[from][msg.sender];
-            if (allowed != type(uint256).max) {
+            if (allowed != UINT256_MAX) {
                 require(allowed >= value, "WETH: request exceeds allowance");
                 uint256 reduced = allowed - value;
                 allowance[from][msg.sender] = reduced;
@@ -392,6 +396,8 @@ contract WETHMock {
 }
 
 contract DAIMock {
+
+    uint internal UINT_MAX = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
     uint256 public totalSupply;
 
@@ -437,7 +443,7 @@ contract DAIMock {
         public returns (bool)
     {
         require(balanceOf[src] >= wad, "Dai/insufficient-balance");
-        if (src != msg.sender && allowance[src][msg.sender] != type(uint).max) {
+        if (src != msg.sender && allowance[src][msg.sender] != UINT_MAX) {
             require(allowance[src][msg.sender] >= wad, "Dai/insufficient-allowance");
             allowance[src][msg.sender] = allowance[src][msg.sender] - wad;
         }
@@ -455,6 +461,8 @@ contract DAIMock {
 }
 
 contract USDCMock {
+    uint256 internal UINT256_MAX = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+
     uint256 private _totalSupply;
         
     mapping(address account => uint256) private _balances;  
@@ -537,7 +545,7 @@ contract USDCMock {
 
     function _spendAllowance(address owner, address spender, uint256 value) internal {
         uint256 currentAllowance = allowance(owner, spender);
-        if (currentAllowance != type(uint256).max) {
+        if (currentAllowance != UINT256_MAX) {
             require(currentAllowance >= value, "USDC: insufficient allowance");
             _approve(owner, spender, currentAllowance - value, false);
             

--- a/test/examples/tokens/SomeToken.sol
+++ b/test/examples/tokens/SomeToken.sol
@@ -7,6 +7,8 @@ pragma solidity ^0.8.20;
 
 contract SomeToken {
 
+    uint256 internal UINT256_MAX = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+
     uint256 private _totalSupply;
 
     string private _name;
@@ -113,7 +115,7 @@ contract SomeToken {
 
     function _spendAllowance(address owner, address spender, uint256 value) internal {
         uint256 currentAllowance = allowance(owner, spender);
-        if (currentAllowance != type(uint256).max) {
+        if (currentAllowance != UINT256_MAX) {
             require(currentAllowance >= value, "SomeToken: insufficient allowance");
             _approve(owner, spender, currentAllowance - value, false);
             


### PR DESCRIPTION
This PR removes the `type` function calls currently present in the tests. It was only used in expressions of the form
```
type(uint*).max
```
I opted to use a variable that stores the expected value and use it instead of the function call.

We can make it a constant when/if these are planned.

Edit: Resolves #1750