### PR TITLE
fix minor bug in semantics

### DIFF
--- a/src/solidity-syntax.md
+++ b/src/solidity-syntax.md
@@ -14,6 +14,8 @@ We use `bool`, `string` and `id` modules, `int`s are defined in a custom way due
     imports BOOL-SYNTAX
     imports STRING-SYNTAX
     imports ID-SYNTAX
+
+    syntax KResult
 ```
 
 ## Tokens-keywords


### PR DESCRIPTION
This PR fixes a minor issue that occurs if the `hybrid` attribute is declared in a module that does not declare the `KResult` sort.