### PR TITLE
Reference sort

### DIFF
--- a/src/solidity.md
+++ b/src/solidity.md
@@ -117,6 +117,11 @@ module SOLIDITY-DATA
   syntax CallArgumentList ::= TypedVals
   syntax KResult ::= TypedVal
   syntax Value ::= MInt{8} | MInt{32} | MInt{112} | MInt{160} | MInt{256} | Bool | String
+  syntax Reference ::= stateVarRef(Id)
+                     | localVarRef(Int)
+                     | mappingValueRef(Reference, Value)
+                     | arrayElementRef(Reference, Value)
+  syntax Value ::= Reference
 
   syntax List ::= getTypes(ParameterList) [function]
   rule getTypes(.ParameterList) => .List


### PR DESCRIPTION
Small PR, that introduces the reference sort with constructors for references to
- state variables
- local variables
- variables of complex types such as mappings and arrays. These have a reference as a base, and an additional value to be used to find the referred to object, e.g. value or element respectively.