### PR TITLE
Summaries for SortTokens function (for non reverting cases).

### DIFF
--- a/src/solidity.md
+++ b/src/solidity.md
@@ -181,7 +181,7 @@ module SOLIDITY
   imports SOLIDITY-TRANSACTION
   imports SOLIDITY-EXPRESSION
   imports SOLIDITY-STATEMENT
-  imports SOLIDITY-UNISWAP-INIT-SUMMARY
+  imports SOLIDITY-UNISWAP-SUMMARIES
 
   rule <k> _:PragmaDefinition Ss:SourceUnits => Ss ...</k>
        <summarize> false </summarize>

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2407,18 +2407,20 @@ module SOLIDITY-UNISWAP-SORTTOKENS-SUMMARY
   rule <k> uniswapV2LibrarySortTokens:Id ( v(V1:MInt{160}, address #as T), v(V2:MInt{160}, T), .TypedVals ) => v(ListItem(V1) ListItem(V2), T[]) ...</k>
        <summarize> true </summarize>
        <store>
-         ... .Map => ((!_:Int |-> V1) (!_:Int |-> V2) (!_:Int |-> default(T[]))
-                      (!_:Int |-> (ListItem(V1) ListItem(V2)))
-                     )
+         S => S ListItem(V1)
+                ListItem(V2)
+                ListItem(default(T[]))
+                ListItem(ListItem(V1) ListItem(V2))
        </store>
     requires V1 <uMInt V2 andBool V1 =/=MInt 0p160 [priority(40)]
 
   rule <k> uniswapV2LibrarySortTokens:Id ( v(V1:MInt{160}, address #as T), v(V2:MInt{160}, T), .TypedVals ) => v(ListItem(V2) ListItem(V1), T[]) ...</k>
        <summarize> true </summarize>
        <store>
-         ... .Map => ((!_:Int |-> V1) (!_:Int |-> V2) (!_:Int |-> default(T[]))
-                      (!_:Int |-> (ListItem(V2) ListItem(V1)))
-                     )
+         S => S ListItem(V1)
+                ListItem(V2)
+                ListItem(default(T[]))
+                ListItem(ListItem(V2) ListItem(V1))
        </store>
     requires V2 <uMInt V1 andBool V2 =/=MInt 0p160 [priority(40)]
 

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2397,3 +2397,37 @@ module SOLIDITY-UNISWAP-INIT-SUMMARY
 
 endmodule
 ```
+
+```k
+module SOLIDITY-UNISWAP-SORTTOKENS-SUMMARY
+  imports SOLIDITY-CONFIGURATION
+  imports SOLIDITY-EXPRESSION
+  imports SOLIDITY-UNISWAP-TOKENS
+
+  rule <k> uniswapV2LibrarySortTokens:Id ( v(V1:MInt{160}, address #as T), v(V2:MInt{160}, T), .TypedVals ) => v(ListItem(V1) ListItem(V2), T[]) ...</k>
+       <summarize> true </summarize>
+       <store>
+         ... .Map => ((!_:Int |-> V1) (!_:Int |-> V2) (!_:Int |-> default(T[]))
+                      (!_:Int |-> (ListItem(V1) ListItem(V2)))
+                     )
+       </store>
+    requires V1 <uMInt V2 andBool V1 =/=MInt 0p160 [priority(40)]
+
+  rule <k> uniswapV2LibrarySortTokens:Id ( v(V1:MInt{160}, address #as T), v(V2:MInt{160}, T), .TypedVals ) => v(ListItem(V2) ListItem(V1), T[]) ...</k>
+       <summarize> true </summarize>
+       <store>
+         ... .Map => ((!_:Int |-> V1) (!_:Int |-> V2) (!_:Int |-> default(T[]))
+                      (!_:Int |-> (ListItem(V2) ListItem(V1)))
+                     )
+       </store>
+    requires V2 <uMInt V1 andBool V2 =/=MInt 0p160 [priority(40)]
+
+endmodule
+```
+
+```k
+module SOLIDITY-UNISWAP-SUMMARIES
+  imports SOLIDITY-UNISWAP-INIT-SUMMARY
+  imports SOLIDITY-UNISWAP-SORTTOKENS-SUMMARY
+endmodule
+```


### PR DESCRIPTION
This PR adds the first summarized rules w.r.t. program execution. These two rules summarize the `uniswapV2LibrarySortTokens` function.
We focus on the two cases that satisfy the requires clauses, and thus will not revert.
Each rule summarizes the execution of about 114 steps.