### PR TITLE
Summary for `uniswapV2LibraryGetAmountOut` and `uniswapV2LibraryGetAmountIn`

### DIFF
--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2397,3 +2397,58 @@ module SOLIDITY-UNISWAP-INIT-SUMMARY
 
 endmodule
 ```
+
+```k
+module SOLIDITY-UNISWAP-SORTTOKENS-SUMMARY
+  imports SOLIDITY-CONFIGURATION
+  imports SOLIDITY-EXPRESSION
+  imports SOLIDITY-UNISWAP-TOKENS
+
+  rule <k> uniswapV2LibrarySortTokens:Id ( v(V1:MInt{160}, address #as T), v(V2:MInt{160}, T), .TypedVals ) => v(ListItem(V1) ListItem(V2), T[]) ...</k>
+       <summarize> true </summarize>
+       <store>
+         S => S ListItem(V1)
+                ListItem(V2)
+                ListItem(default(T[]))
+                ListItem(ListItem(V1) ListItem(V2))
+       </store>
+    requires V1 <uMInt V2 andBool V1 =/=MInt 0p160 [priority(40)]
+
+  rule <k> uniswapV2LibrarySortTokens:Id ( v(V1:MInt{160}, address #as T), v(V2:MInt{160}, T), .TypedVals ) => v(ListItem(V2) ListItem(V1), T[]) ...</k>
+       <summarize> true </summarize>
+       <store>
+         S => S ListItem(V1)
+                ListItem(V2)
+                ListItem(default(T[]))
+                ListItem(ListItem(V2) ListItem(V1))
+       </store>
+    requires V2 <uMInt V1 andBool V2 =/=MInt 0p160 [priority(40)]
+
+endmodule
+```
+
+```k
+module SOLIDITY-UNISWAP-GETAMOUNTOUT-SUMMARY
+  imports SOLIDITY-CONFIGURATION
+  imports SOLIDITY-UNISWAP-TOKENS
+  
+  rule <k> uniswapV2LibraryGetAmountOut:Id ( v(V1:MInt{256}, uint256 #as T), v(V2:MInt{256}, T), v(V3:MInt{256}, T), .TypedVals ) => v((V1 *MInt 997p256  *MInt V3) /uMInt (V2 *MInt 1000p256 +MInt V1 *MInt 997p256), T) ...</k>
+       <summarize> true </summarize>
+       <store> S => S ListItem(V1) ListItem(V2) ListItem(V3)
+                      ListItem((V1 *MInt 997p256  *MInt V3) /uMInt (V2 *MInt 1000p256 +MInt V1 *MInt 997p256) ) // amountOut
+                      ListItem( V1 *MInt 997p256)                                                               // amountInWithFee
+                      ListItem( V1 *MInt 997p256  *MInt V3)                                                     // numerator
+                      ListItem( V2 *MInt 1000p256 +MInt V1  *MInt 997p256)                                      // denominator
+       </store>
+    requires V1 >uMInt 0p256 andBool V2 >uMInt 0p256 andBool V3 >uMInt 0p256 [priority(40)]
+
+endmodule
+```
+
+```k
+module SOLIDITY-UNISWAP-SUMMARIES
+  imports SOLIDITY-UNISWAP-INIT-SUMMARY
+  imports SOLIDITY-UNISWAP-SORTTOKENS-SUMMARY
+  imports SOLIDITY-UNISWAP-GETAMOUNTOUT-SUMMARY
+endmodule
+```

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2446,9 +2446,40 @@ endmodule
 ```
 
 ```k
+module SOLIDITY-UNISWAP-GETAMOUNTIN-SUMMARY
+  imports SOLIDITY-CONFIGURATION
+  imports SOLIDITY-UNISWAP-TOKENS
+
+  rule <k> uniswapV2LibraryGetAmountIn:Id ( v(V1:MInt{256}, uint256 #as T), v(V2:MInt{256}, T), v(V3:MInt{256}, T), .TypedVals ) => v(((V2 *MInt V1 *MInt 1000p256) /uMInt ((V3 -MInt V1) *MInt 997p256)) +MInt 1p256, T) ...</k>
+       <summarize> true </summarize>
+       <store> S => S ListItem(V1) ListItem(V2) ListItem(V3)
+                      ListItem(((V2 *MInt V1 *MInt 1000p256) /uMInt ((V3 -MInt V1) *MInt 997p256)) +MInt 1p256) // amountIn
+                      ListItem(V2 *MInt V1 *MInt 1000p256)                                                      // numerator
+                      ListItem((V3 -MInt V1) *MInt 997p256)                                                     // denominator
+       </store>
+    requires V1 >uMInt 0p256 andBool V2 >uMInt 0p256 andBool V3 >uMInt 0p256
+     andBool ((V3 -MInt V1) *MInt 997p256) =/=MInt 0p256 [priority(40)]
+
+
+    rule <k> uniswapV2LibraryGetAmountIn:Id ( v(V1:MInt{256}, uint256 #as T), v(V2:MInt{256}, T), v(V3:MInt{256}, T), .TypedVals ) => v(1p256, T) ...</k>
+       <summarize> true </summarize>
+       <store> S => S ListItem(V1) ListItem(V2) ListItem(V3)
+                      ListItem(1p256)                        // amountIn
+                      ListItem(V2 *MInt V1 *MInt 1000p256)   // numerator
+                      ListItem((V3 -MInt V1) *MInt 997p256)  // denominator
+       </store>
+    requires V1 >uMInt 0p256 andBool V2 >uMInt 0p256 andBool V3 >uMInt 0p256
+     andBool ((V3 -MInt V1) *MInt 997p256) ==MInt 0p256 [priority(40)]
+  
+endmodule
+```
+
+```k
 module SOLIDITY-UNISWAP-SUMMARIES
   imports SOLIDITY-UNISWAP-INIT-SUMMARY
   imports SOLIDITY-UNISWAP-SORTTOKENS-SUMMARY
   imports SOLIDITY-UNISWAP-GETAMOUNTOUT-SUMMARY
+  imports SOLIDITY-UNISWAP-GETAMOUNTIN-SUMMARY
+
 endmodule
 ```


### PR DESCRIPTION
This PR adds two new summarized rules regarding program execution. The rule presented in this PR summarizes the `uniswapV2LibraryGetAmountOut` and `uniswapV2LibraryGetAmountIn` functions.

By summarizing the `uniswapV2LibraryGetAmountOut` function, we save 380 steps.
(Without it, the program took 26748, and after implementing it, the program took 26368)

By summarizing the `uniswapV2LibraryGetAmountIn` function, we save 408 steps.
(Without it, the program took 26368, and after implementing it, the program took 25960)
