### PR TITLE
Remove strict and context from the definition

### DIFF
--- a/src/expression.md
+++ b/src/expression.md
@@ -515,4 +515,138 @@ module SOLIDITY-EXPRESSION
   rule retval(.List) => void
   rule retval(ListItem(noId)) => void
   rule retval(ListItem(X:Id)) => X
+
+  // Heating and cooling rules
+  syntax KItem ::= freezerAssignment(Expression)
+  rule <k> E:Expression = HOLE:Expression => HOLE ~> freezerAssignment(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerAssignment(E) => E = HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerTernaryOperator(Expression, Expression)
+  rule <k> HOLE:Expression ? E1:Expression : E2:Expression => HOLE ~> freezerTernaryOperator(E1, E2) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerTernaryOperator(E1, E2) => HOLE ? E1 : E2 ...</k> [cool]
+
+  syntax KItem ::= freezerOr(Expression)
+  rule <k> HOLE:Expression || E:Expression => HOLE ~> freezerOr(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerOr(E) => HOLE || E ...</k> [cool]
+
+  syntax KItem ::= freezerAnd(Expression)
+  rule <k> HOLE:Expression && E:Expression => HOLE ~> freezerAnd(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerAnd(E) => HOLE && E ...</k> [cool]
+
+  syntax KItem ::= freezerEq1(Expression)
+                 | freezerEq2(Expression)
+  rule <k> HOLE:Expression == E:Expression => HOLE ~> freezerEq1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerEq1(E) => HOLE == E ...</k> [cool]
+  rule <k> E:Expression == HOLE:Expression => HOLE ~> freezerEq2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerEq2(E) => E == HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerNeq1(Expression)
+                 | freezerNeq2(Expression)
+  rule <k> HOLE:Expression != E:Expression => HOLE ~> freezerNeq1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerNeq1(E) => HOLE != E ...</k> [cool]
+  rule <k> E:Expression != HOLE:Expression => HOLE ~> freezerNeq2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerNeq2(E) => E != HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerLt1(Expression)
+                 | freezerLt2(Expression)
+  rule <k> HOLE:Expression < E:Expression => HOLE ~> freezerLt1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerLt1(E) => HOLE < E ...</k> [cool]
+  rule <k> E:Expression < HOLE:Expression => HOLE ~> freezerLt2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerLt2(E) => E < HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerLeq1(Expression)
+                 | freezerLeq2(Expression)
+  rule <k> HOLE:Expression <= E:Expression => HOLE ~> freezerLeq1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerLeq1(E) => HOLE <= E ...</k> [cool]
+  rule <k> E:Expression <= HOLE:Expression => HOLE ~> freezerLeq2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerLeq2(E) => E <= HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerGt1(Expression)
+                 | freezerGt2(Expression)
+  rule <k> HOLE:Expression > E:Expression => HOLE ~> freezerGt1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerGt1(E) => HOLE > E ...</k> [cool]
+  rule <k> E:Expression > HOLE:Expression => HOLE ~> freezerGt2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerGt2(E) => E > HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerGeq1(Expression)
+                 | freezerGeq2(Expression)
+  rule <k> HOLE:Expression >= E:Expression => HOLE ~> freezerGeq1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerGeq1(E) => HOLE >= E ...</k> [cool]
+  rule <k> E:Expression >= HOLE:Expression => HOLE ~> freezerGeq2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerGeq2(E) => E >= HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerAdd1(Expression)
+                 | freezerAdd2(Expression)
+  rule <k> HOLE:Expression + E:Expression => HOLE ~> freezerAdd1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerAdd1(E) => HOLE + E ...</k> [cool]
+  rule <k> E:Expression + HOLE:Expression => HOLE ~> freezerAdd2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerAdd2(E) => E + HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerSub1(Expression)
+                 | freezerSub2(Expression)
+  rule <k> HOLE:Expression - E:Expression => HOLE ~> freezerSub1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerSub1(E) => HOLE - E ...</k> [cool]
+  rule <k> E:Expression - HOLE:Expression => HOLE ~> freezerSub2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerSub2(E) => E - HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerMul1(Expression)
+                 | freezerMul2(Expression)
+  rule <k> HOLE:Expression * E:Expression => HOLE ~> freezerMul1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerMul1(E) => HOLE * E ...</k> [cool]
+  rule <k> E:Expression * HOLE:Expression => HOLE ~> freezerMul2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerMul2(E) => E * HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerDiv1(Expression)
+                 | freezerDiv2(Expression)
+  rule <k> HOLE:Expression / E:Expression => HOLE ~> freezerDiv1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerDiv1(E) => HOLE / E ...</k> [cool]
+  rule <k> E:Expression / HOLE:Expression => HOLE ~> freezerDiv2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerDiv2(E) => E / HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerMod1(Expression)
+                 | freezerMod2(Expression)
+  rule <k> HOLE:Expression % E:Expression => HOLE ~> freezerMod1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerMod1(E) => HOLE % E ...</k> [cool]
+  rule <k> E:Expression % HOLE:Expression => HOLE ~> freezerMod2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerMod2(E) => E % HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerExp1(Expression)
+                 | freezerExp2(Expression)
+  rule <k> HOLE:Expression ** E:Expression => HOLE ~> freezerExp1(E) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerExp1(E) => HOLE ** E ...</k> [cool]
+  rule <k> E:Expression ** HOLE:Expression => HOLE ~> freezerExp2(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:Expression ~> freezerExp2(E) => E ** HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerNew(TypeName)
+  rule <k> new T:TypeName ( HOLE:CallArgumentList ) => HOLE ~> freezerNew(T) ...</k> [heat]
+  rule <k> HOLE:CallArgumentList ~> freezerNew(T) => new T ( HOLE ) ...</k> [cool]
+
+  syntax KItem ::= freezerCallArgumentListHead(Expression)
+                 | freezerCallArgumentListTail(CallArgumentList)
+  rule <k> HOLE:Expression, L:CallArgumentList => HOLE ~> freezerCallArgumentListTail(L) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerCallArgumentListTail(L) => HOLE, L ...</k> [cool]
+  rule <k> E:Expression, HOLE:CallArgumentList => HOLE ~> freezerCallArgumentListHead(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:CallArgumentList ~> freezerCallArgumentListHead(E) => E, HOLE ...</k> [cool]
+
+  syntax KItem ::= freezerTypedValsHead(TypedVal)
+                 | freezerTypedValsTail(TypedVals)
+  rule <k> HOLE:TypedVal, L:TypedVals => HOLE ~> freezerTypedValsTail(L) ...</k> [heat]
+  rule <k> HOLE:TypedVal ~> freezerTypedValsTail(L) => HOLE, L ...</k> [cool]
+  rule <k> E:TypedVal, HOLE:TypedVals => HOLE ~> freezerTypedValsHead(E) ...</k>
+    requires isKResult(E) [heat]
+  rule <k> HOLE:TypedVals ~> freezerTypedValsHead(E) => E, HOLE ...</k> [cool]
+
 endmodule

--- a/src/expression.md
+++ b/src/expression.md
@@ -524,96 +524,84 @@ module SOLIDITY-EXPRESSION
                  | freezerEq2(Expression)
   rule <k> HOLE:Expression == E:Expression => HOLE ~> freezerEq1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerEq1(E) => HOLE == E ...</k> [cool]
-  rule <k> E:Expression == HOLE:Expression => HOLE ~> freezerEq2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression == HOLE:Expression => HOLE ~> freezerEq2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerEq2(E) => E == HOLE ...</k> [cool]
 
   syntax KItem ::= freezerNeq1(Expression)
                  | freezerNeq2(Expression)
   rule <k> HOLE:Expression != E:Expression => HOLE ~> freezerNeq1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerNeq1(E) => HOLE != E ...</k> [cool]
-  rule <k> E:Expression != HOLE:Expression => HOLE ~> freezerNeq2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression != HOLE:Expression => HOLE ~> freezerNeq2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerNeq2(E) => E != HOLE ...</k> [cool]
 
   syntax KItem ::= freezerLt1(Expression)
                  | freezerLt2(Expression)
   rule <k> HOLE:Expression < E:Expression => HOLE ~> freezerLt1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerLt1(E) => HOLE < E ...</k> [cool]
-  rule <k> E:Expression < HOLE:Expression => HOLE ~> freezerLt2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression < HOLE:Expression => HOLE ~> freezerLt2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerLt2(E) => E < HOLE ...</k> [cool]
 
   syntax KItem ::= freezerLeq1(Expression)
                  | freezerLeq2(Expression)
   rule <k> HOLE:Expression <= E:Expression => HOLE ~> freezerLeq1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerLeq1(E) => HOLE <= E ...</k> [cool]
-  rule <k> E:Expression <= HOLE:Expression => HOLE ~> freezerLeq2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression <= HOLE:Expression => HOLE ~> freezerLeq2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerLeq2(E) => E <= HOLE ...</k> [cool]
 
   syntax KItem ::= freezerGt1(Expression)
                  | freezerGt2(Expression)
   rule <k> HOLE:Expression > E:Expression => HOLE ~> freezerGt1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerGt1(E) => HOLE > E ...</k> [cool]
-  rule <k> E:Expression > HOLE:Expression => HOLE ~> freezerGt2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression > HOLE:Expression => HOLE ~> freezerGt2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerGt2(E) => E > HOLE ...</k> [cool]
 
   syntax KItem ::= freezerGeq1(Expression)
                  | freezerGeq2(Expression)
   rule <k> HOLE:Expression >= E:Expression => HOLE ~> freezerGeq1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerGeq1(E) => HOLE >= E ...</k> [cool]
-  rule <k> E:Expression >= HOLE:Expression => HOLE ~> freezerGeq2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression >= HOLE:Expression => HOLE ~> freezerGeq2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerGeq2(E) => E >= HOLE ...</k> [cool]
 
   syntax KItem ::= freezerAdd1(Expression)
                  | freezerAdd2(Expression)
   rule <k> HOLE:Expression + E:Expression => HOLE ~> freezerAdd1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerAdd1(E) => HOLE + E ...</k> [cool]
-  rule <k> E:Expression + HOLE:Expression => HOLE ~> freezerAdd2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression + HOLE:Expression => HOLE ~> freezerAdd2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerAdd2(E) => E + HOLE ...</k> [cool]
 
   syntax KItem ::= freezerSub1(Expression)
                  | freezerSub2(Expression)
   rule <k> HOLE:Expression - E:Expression => HOLE ~> freezerSub1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerSub1(E) => HOLE - E ...</k> [cool]
-  rule <k> E:Expression - HOLE:Expression => HOLE ~> freezerSub2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression - HOLE:Expression => HOLE ~> freezerSub2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerSub2(E) => E - HOLE ...</k> [cool]
 
   syntax KItem ::= freezerMul1(Expression)
                  | freezerMul2(Expression)
   rule <k> HOLE:Expression * E:Expression => HOLE ~> freezerMul1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerMul1(E) => HOLE * E ...</k> [cool]
-  rule <k> E:Expression * HOLE:Expression => HOLE ~> freezerMul2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression * HOLE:Expression => HOLE ~> freezerMul2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerMul2(E) => E * HOLE ...</k> [cool]
 
   syntax KItem ::= freezerDiv1(Expression)
                  | freezerDiv2(Expression)
   rule <k> HOLE:Expression / E:Expression => HOLE ~> freezerDiv1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerDiv1(E) => HOLE / E ...</k> [cool]
-  rule <k> E:Expression / HOLE:Expression => HOLE ~> freezerDiv2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression / HOLE:Expression => HOLE ~> freezerDiv2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerDiv2(E) => E / HOLE ...</k> [cool]
 
   syntax KItem ::= freezerMod1(Expression)
                  | freezerMod2(Expression)
   rule <k> HOLE:Expression % E:Expression => HOLE ~> freezerMod1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerMod1(E) => HOLE % E ...</k> [cool]
-  rule <k> E:Expression % HOLE:Expression => HOLE ~> freezerMod2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression % HOLE:Expression => HOLE ~> freezerMod2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerMod2(E) => E % HOLE ...</k> [cool]
 
   syntax KItem ::= freezerExp1(Expression)
                  | freezerExp2(Expression)
   rule <k> HOLE:Expression ** E:Expression => HOLE ~> freezerExp1(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerExp1(E) => HOLE ** E ...</k> [cool]
-  rule <k> E:Expression ** HOLE:Expression => HOLE ~> freezerExp2(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression ** HOLE:Expression => HOLE ~> freezerExp2(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerExp2(E) => E ** HOLE ...</k> [cool]
 
   syntax KItem ::= freezerNew(TypeName)
@@ -624,24 +612,21 @@ module SOLIDITY-EXPRESSION
                  | freezerCallArgumentListTail(CallArgumentList)
   rule <k> HOLE:Expression, L:CallArgumentList => HOLE ~> freezerCallArgumentListTail(L) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerCallArgumentListTail(L) => HOLE, L ...</k> [cool]
-  rule <k> E:Expression, HOLE:CallArgumentList => HOLE ~> freezerCallArgumentListHead(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression, HOLE:CallArgumentList => HOLE ~> freezerCallArgumentListHead(E) ...</k> [heat]
   rule <k> HOLE:CallArgumentList ~> freezerCallArgumentListHead(E) => E, HOLE ...</k> [cool]
 
   syntax KItem ::= freezerTypedValsHead(TypedVal)
                  | freezerTypedValsTail(TypedVals)
   rule <k> HOLE:TypedVal, L:TypedVals => HOLE ~> freezerTypedValsTail(L) ...</k> [heat]
   rule <k> HOLE:TypedVal ~> freezerTypedValsTail(L) => HOLE, L ...</k> [cool]
-  rule <k> E:TypedVal, HOLE:TypedVals => HOLE ~> freezerTypedValsHead(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:TypedVal, HOLE:TypedVals => HOLE ~> freezerTypedValsHead(E) ...</k> [heat]
   rule <k> HOLE:TypedVals ~> freezerTypedValsHead(E) => E, HOLE ...</k> [cool]
 
   syntax KItem ::= freezerAssignmentToArrayElementBase(Expression, Expression)
                  | freezerAssignmentToArrayElementIndex(Expression, Expression)
   rule <k> HOLE:Expression [ E2:Expression ] = E3:Expression => HOLE ~> freezerAssignmentToArrayElementBase(E2, E3) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerAssignmentToArrayElementBase(E2, E3) => HOLE [ E2 ] = E3 ...</k> [cool]
-  rule <k> E1:Expression [ HOLE:Expression ] = E3:Expression => HOLE ~> freezerAssignmentToArrayElementIndex(E1, E3) ...</k>
-    requires isKResult(E1) [heat]
+  rule <k> E1:Expression [ HOLE:Expression ] = E3:Expression => HOLE ~> freezerAssignmentToArrayElementIndex(E1, E3) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerAssignmentToArrayElementIndex(E1, E3) => E1 [ HOLE ] = E3 ...</k> [cool]
 
   syntax KItem ::= freezerCallElementaryTypeName(ElementaryTypeName)
@@ -656,8 +641,7 @@ module SOLIDITY-EXPRESSION
                  | freezerArrayElementLookupIndex(Expression)
   rule <k> HOLE:Expression [ E:Expression ] => HOLE ~> freezerArrayElementLookupBase(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerArrayElementLookupBase(E) => HOLE [ E ] ...</k> [cool]
-  rule <k> E:Expression [ HOLE:Expression ] => HOLE ~> freezerArrayElementLookupIndex(E) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression [ HOLE:Expression ] => HOLE ~> freezerArrayElementLookupIndex(E) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerArrayElementLookupIndex(E) => E [ HOLE ] ...</k> [cool]
 
   syntax KItem ::= freezerLength()
@@ -668,20 +652,17 @@ module SOLIDITY-EXPRESSION
                  | freezerExternalCallArgs(Expression, Id)
   rule <k> HOLE:Expression . ID:Id ( ARGS:CallArgumentList ) => HOLE ~> freezerExternalCallBase(ID, ARGS) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerExternalCallBase(ID, ARGS) => (HOLE . ID) ( ARGS ) ...</k> [cool]
-  rule <k> (E:Expression . ID:Id) ( HOLE:CallArgumentList ) => HOLE ~> freezerExternalCallArgs(E, ID) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> (E:Expression . ID:Id) ( HOLE:CallArgumentList ) => HOLE ~> freezerExternalCallArgs(E, ID) ...</k> [heat]
   rule <k> HOLE:CallArgumentList ~> freezerExternalCallArgs(E, ID) => (E . ID) ( HOLE ) ...</k> [cool]
 
   syntax KItem ::= freezerExternalCallWithValueBase(Id, Expression, CallArgumentList)
                  | freezerExternalCallWithValueValue(Expression, Id, CallArgumentList)
-                 | freezerExternalCallWithValueArgs(Expression, Id, Expression)
+                 | freezerExternalCallWithValueArgs(Expression, Id, KeyValues)
   rule <k> HOLE:Expression . ID:Id { value: V:Expression } ( ARGS:CallArgumentList ) => HOLE ~> freezerExternalCallWithValueBase(ID, V, ARGS) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerExternalCallWithValueBase(ID, V, ARGS) => HOLE . ID { value : V } ( ARGS ) ...</k> [cool]
-  rule <k> E:Expression . ID:Id { value: HOLE:Expression } ( ARGS:CallArgumentList ) => HOLE ~> freezerExternalCallWithValueValue(E, ID, ARGS) ...</k>
-    requires isKResult(E) [heat]
+  rule <k> E:Expression . ID:Id { value: HOLE:Expression } ( ARGS:CallArgumentList ) => HOLE ~> freezerExternalCallWithValueValue(E, ID, ARGS) ...</k> [heat]
   rule <k> HOLE:Expression ~> freezerExternalCallWithValueValue(E, ID, ARGS) => E . ID { value : HOLE } ( ARGS ) ...</k> [cool]
-  rule <k> E:Expression . ID:Id { value: V:Expression } ( HOLE:CallArgumentList ) => HOLE ~> freezerExternalCallWithValueArgs(E, ID, V) ...</k>
-    requires isKResult(E) andBool isKResult(V) [heat]
-  rule <k> HOLE:Expression ~> freezerExternalCallWithValueArgs(E, ID, V) => E . ID { value : V } ( HOLE ) ...</k> [cool]
+  rule <k> E:Expression . ID:Id { L:KeyValues } ( HOLE:CallArgumentList ) => HOLE ~> freezerExternalCallWithValueArgs(E, ID, L) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerExternalCallWithValueArgs(E, ID, L) => E . ID { L } ( HOLE ) ...</k> [cool]
 
 endmodule

--- a/src/solidity-syntax.md
+++ b/src/solidity-syntax.md
@@ -179,23 +179,23 @@ In each code block, various statments and nested blocks can be present.
 Following is a list of supported statements.
 
 ```k
-    syntax ExpressionStatement ::= Expression ";" [strict]
+    syntax ExpressionStatement ::= Expression ";"
 
     syntax VariableDeclarationStatement ::= VariableDeclaration ";"
-                                            | VariableDeclaration "=" Expression ";" [strict(2)]
-                                            | "(" VariableDeclaration "," ")" "=" Expression ";" [strict(2)]
+                                            | VariableDeclaration "=" Expression ";"
+                                            | "(" VariableDeclaration "," ")" "=" Expression ";"
 
-    syntax IfStatement ::= "if" "(" Expression ")" Statement [strict(1)]
-                         | "if" "(" Expression ")" Statement "else" Statement [avoid, strict(1)]
+    syntax IfStatement ::= "if" "(" Expression ")" Statement
+                         | "if" "(" Expression ")" Statement "else" Statement [avoid]
 
     syntax WhileStatement ::= "while" "(" Expression ")" Statement
     syntax Block ::= "for" "(" VariableDeclarationStatement Expression ";" Expression ")" Statement [function]
     rule for (Init Cond ; Post) Body => { Init while(Cond) { Body Post; } }
 
-    syntax EmitStatement ::= "emit" Expression "(" CallArgumentList ")" ";" [strict(2)]
+    syntax EmitStatement ::= "emit" Expression "(" CallArgumentList ")" ";"
 
     syntax ReturnStatement ::= "return" ";"
-                            | "return" Expression ";" [strict]
+                            | "return" Expression ";"
 
     syntax RevertStatement ::= "revert" "(" CallArgumentList ")" ";"
                              | "revert" Id "(" CallArgumentList ")" ";"
@@ -207,7 +207,7 @@ Following is a list of supported statements.
 `CallArgumentList` keeps a list of arguments for function calls and such (`revert()`, `emit()`, etc.)
 
 ```k
-    syntax CallArgumentList ::= List{Expression, ","} [overload(exps), strict]
+    syntax CallArgumentList ::= List{Expression, ","} [overload(exps)]
 
 ```
 
@@ -227,7 +227,7 @@ Following is a list of supported expressions. Operator precendences are taken fr
     syntax Expression ::= Id | Literal | LiteralWithSubDenom | ElementaryTypeName
                         > "(" Expression ")" [bracket]
                         | "[" CallArgumentList "]"
-                        | "new" TypeName "(" CallArgumentList ")" [strict(2)]
+                        | "new" TypeName "(" CallArgumentList ")"
                         | Expression "++" | Expression "--"
                         | Expression "[" Expression "]" | Expression "[""]"
                         | Expression "." Id | Expression ".address"
@@ -235,28 +235,27 @@ Following is a list of supported expressions. Operator precendences are taken fr
                         | Expression "(" CallArgumentList ")"
                         > "++" Expression | "--" Expression
                         | "!" Expression
-                        > left: Expression "**" Expression [strict]
+                        > left: Expression "**" Expression
                         > left:
-                              Expression "*" Expression [strict]
-                            | Expression "/" Expression [strict]
-                            | Expression "%" Expression [strict]
+                              Expression "*" Expression
+                            | Expression "/" Expression
+                            | Expression "%" Expression
                         > left:
-                              Expression "+" Expression [strict]
-                            | Expression "-" Expression [strict]
+                              Expression "+" Expression
+                            | Expression "-" Expression
                         > left:
-                              Expression "<" Expression [strict]
-                            | Expression "<=" Expression [strict]
-                            | Expression ">" Expression [strict]
-                            | Expression ">=" Expression [strict]
+                              Expression "<" Expression
+                            | Expression "<=" Expression
+                            | Expression ">" Expression
+                            | Expression ">=" Expression
                         > left:
-                              Expression "==" Expression [strict]
-                            | Expression "!=" Expression [strict]
-                        > left: Expression "&&" Expression [strict(1)]
-                        > left: Expression "||" Expression [strict(1)]
+                              Expression "==" Expression
+                            | Expression "!=" Expression
+                        > left: Expression "&&" Expression
+                        > left: Expression "||" Expression
                         > right:
-                            Expression "?" Expression ":" Expression [strict(1)]
-                            | Expression "=" Expression [strict(2)]
-
+                            Expression "?" Expression ":" Expression
+                            | Expression "=" Expression
 endmodule
 
 ```

--- a/src/solidity.md
+++ b/src/solidity.md
@@ -100,7 +100,7 @@ module SOLIDITY-DATA-SYNTAX
 
   syntax Transactions ::= List{Transaction, ","}
   syntax Transaction ::= txn(from: Decimal, to: Decimal, value: Decimal, timestamp: Decimal, func: Id, args: CallArgumentList) [function]
-  syntax Transaction ::= create(from: Decimal, value: Decimal, timestamp: Decimal, ctor: Id, args: CallArgumentList) [strict(5)]
+  syntax Transaction ::= create(from: Decimal, value: Decimal, timestamp: Decimal, ctor: Id, args: CallArgumentList)
 endmodule
 
 module SOLIDITY-DATA
@@ -118,7 +118,7 @@ module SOLIDITY-DATA
   syntax Id ::= "constructor" [token]
 
   syntax TypedVal ::= v(Value, TypeName) | lv(BaseRef, List, TypeName) | Int | String | "void"
-  syntax TypedVals ::= List{TypedVal, ","} [overload(exps), strict]
+  syntax TypedVals ::= List{TypedVal, ","} [overload(exps)]
   syntax Expression ::= TypedVal
   syntax CallArgumentList ::= TypedVals
   syntax KResult ::= TypedVal | TypedVals

--- a/src/statement.md
+++ b/src/statement.md
@@ -88,4 +88,33 @@ module SOLIDITY-STATEMENT
   // while statement
   rule while (Cond) Body => if (Cond) {Body while(Cond) Body} else {.Statements}
 
+  // Heating and cooling rules
+  syntax KItem ::= freezerExpressionStatement()
+  rule <k> HOLE:Expression ; => HOLE ~> freezerExpressionStatement() ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerExpressionStatement() => HOLE ; ...</k> [cool]
+
+  syntax KItem ::= freezerVariableDeclarationStatementA(VariableDeclaration)
+  rule <k> D:VariableDeclaration = HOLE:Expression ; => HOLE ~> freezerVariableDeclarationStatementA(D) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerVariableDeclarationStatementA(D) => D = HOLE ; ...</k> [cool]
+
+  syntax KItem ::= freezerVariableDeclarationStatementB(VariableDeclaration)
+  rule <k> ( D:VariableDeclaration , ) = HOLE:Expression ; => HOLE ~> freezerVariableDeclarationStatementB(D) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerVariableDeclarationStatementB(D) => ( D , ) = HOLE ; ...</k> [cool]
+
+  syntax KItem ::= freezerIfStatement(Statement)
+  rule <k> if ( HOLE:Expression ) S:Statement => HOLE ~> freezerIfStatement(S) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerIfStatement(S) => if ( HOLE ) S ...</k> [cool]
+
+  syntax KItem ::= freezerIfElseStatement(Statement, Statement)
+  rule <k> if ( HOLE:Expression ) S1:Statement else S2:Statement => HOLE ~> freezerIfElseStatement(S1, S2) ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerIfElseStatement(S1, S2) => if ( HOLE ) S1 else S2 ...</k> [cool]
+
+  syntax KItem ::= freezerEmitStatement(Expression)
+  rule <k> emit E:Expression ( HOLE:CallArgumentList ) ; => HOLE ~> freezerEmitStatement(E) ...</k> [heat]
+  rule <k> HOLE ~> freezerEmitStatement(E) => emit E ( HOLE ) ; ...</k> [cool]
+
+  syntax KItem ::= freezerReturnStatement()
+  rule <k> return HOLE:Expression ; => HOLE ~> freezerReturnStatement() ...</k> [heat]
+  rule <k> HOLE:Expression ~> freezerReturnStatement() => return HOLE ; ...</k> [cool]
+
 endmodule

--- a/src/transaction.md
+++ b/src/transaction.md
@@ -57,7 +57,7 @@ module SOLIDITY-TRANSACTION
        <next-address> ADDR => ADDR +MInt 1p160 </next-address>
     [owise]
 
-  syntax Transaction ::= txn(from: Decimal, to: MInt{160}, value: Decimal, timestamp: Decimal, func: Id, args: CallArgumentList) [strict(6)]
+  syntax Transaction ::= txn(from: Decimal, to: MInt{160}, value: Decimal, timestamp: Decimal, func: Id, args: CallArgumentList)
   rule txn(FROM, TO, VALUE, NOW, FUNC, ARGS) => txn(FROM, Int2MInt(Number2Int(TO)), VALUE, NOW, FUNC, ARGS)
 
   rule <k> txn(FROM, TO, VALUE, NOW, FUNC, ARGS) => bind(.List, PARAMS, TYPES, ARGS, .List, .List) ~> BODY ...</k>
@@ -81,5 +81,12 @@ module SOLIDITY-TRANSACTION
        <contract-fn-arg-types> TYPES </contract-fn-arg-types>
        <contract-fn-body> BODY </contract-fn-body>
     requires isKResult(ARGS)
+
+  syntax KItem ::= freezerTransactionCreate(Decimal, Decimal, Decimal, Id)
+                 | freezerTransactionTxn(Decimal, MInt{160}, Decimal, Decimal, Id)
+  rule <k> create(FROM, VALUE, NOW, CTOR, HOLE:CallArgumentList) => HOLE ~> freezerTransactionCreate(FROM, VALUE, NOW, CTOR) ...</k> [heat]
+  rule <k> HOLE ~> freezerTransactionCreate(FROM, VALUE, NOW, CTOR) => create(FROM, VALUE, NOW, CTOR, HOLE) ...</k> [cool]
+  rule <k> txn(FROM, TO, VALUE, NOW, FUNC, HOLE:CallArgumentList) => HOLE ~> freezerTransactionTxn(FROM, TO, VALUE, NOW, FUNC) ...</k> [heat]
+  rule <k> HOLE:CallArgumentList ~> freezerTransactionTxn(FROM, TO, VALUE, NOW, FUNC) => txn(FROM, TO, VALUE, NOW, FUNC, HOLE) ...</k> [cool]
 
 endmodule

--- a/test/regression/funcnamefail.ref
+++ b/test/regression/funcnamefail.ref
@@ -1,6 +1,6 @@
 <solidity>
   <k>
-    require ( v ( false , bool ) , "" , .TypedVals ) ~> #freezer_;_SOLIDITY-SYNTAX_ExpressionStatement_Expression0_ ( ) ~> return 2 ;  .Statements ~> return void ; ~> .K
+    require ( v ( false , bool ) , "" , .TypedVals ) ~> freezerExpressionStatement ( ) ~> return 2 ;  .Statements ~> return void ; ~> .K
   </k>
   <summarize>
     false
@@ -136,8 +136,8 @@
       chaincall2
     </current-function>
     <call-stack>
-      ListItem ( frame (... continuation: #freezer_=_;_SOLIDITY-SYNTAX_VariableDeclarationStatement_VariableDeclaration_Expression1_ ( uint256 x ~> .K ) ~> .Statements ~> .Transactions ~> .K , env: .Map , func: constructor ) )
-      ListItem ( frame (... continuation: #freezerreturn_;_SOLIDITY-SYNTAX_ReturnStatement_Expression0_ ( ) ~> .Statements ~> return void ; ~> .K , env: .Map , func: chaincall1 ) )
+      ListItem ( frame (... continuation: freezerVariableDeclarationStatementA ( uint256 x ) ~> .Statements ~> .Transactions ~> .K , env: .Map , func: constructor ) )
+      ListItem ( frame (... continuation: freezerReturnStatement ( ) ~> .Statements ~> return void ; ~> .K , env: .Map , func: chaincall1 ) )
     </call-stack>
     <live-contracts>
       <live-contract>


### PR DESCRIPTION
With the freezers generated automatically from K with the use of strict and context, we were unable to use them and thus summarize sequences as long as possible. This PR removes the strict and contexts, and explicitly creates the corresponding freezers and heating-cooling rules.