### PR TITLE
Summary of `getReserves` function

### DIFF
--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2896,12 +2896,13 @@ module SOLIDITY-UNISWAP-GETRESERVES-SUMMARY
   imports SOLIDITY-EXPRESSION
   imports SOLIDITY-UNISWAP-TOKENS
 
-  rule <k> reserves = new uint112 [ ] ( 3 , .TypedVals ) ;  reserves [ 0 ] = reserve0 ;  reserves [ 1 ] = reserve1 ;  reserves [ 2 ] = blockTimestampLast ;  .Statements ~> return reserves ; ~> .K => return v ( ListItem({Storage[reserve0] orDefault 0p112}:>MInt{112}) ListItem({Storage[reserve1] orDefault 0p112}:>MInt{112}) ListItem(roundMInt({Storage[blockTimestampLast] orDefault 0p32}:>MInt{32}):MInt{112}) , uint112 [ ] ) ; ~> .K</k> 
+  rule <k> bind ( _STORE , .List , .List , .TypedVals , ListItem ( uint112 []:TypeName ) , ListItem ( reserves ) ) ~> reserves = new uint112 [ ] ( 3 , .TypedVals ) ;  reserves [ 0 ] = reserve0 ;  reserves [ 1 ] = reserve1 ;  reserves [ 2 ] = blockTimestampLast ;  .Statements ~> return reserves ; ~> .K => return v ( ListItem({Storage[reserve0] orDefault 0p112}:>MInt{112}) ListItem({Storage[reserve1] orDefault 0p112}:>MInt{112}) ListItem(roundMInt({Storage[blockTimestampLast] orDefault 0p32}:>MInt{32}):MInt{112}) , uint112 [ ] ) ; ~> .K</k> 
         <summarize> true </summarize>
         <this> THIS </this>
         <contract-address> THIS </contract-address>
         <this-type> TYPE </this-type>
         <contract-id> TYPE </contract-id>
+        <current-function> getReserves </current-function>
         <env> ENV=> ENV [ reserves <- var(1, uint112 []) ] </env>
         <store> S => S ListItem(
                               ListItem({Storage[reserve0] orDefault 0p112}:>MInt{112})

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2903,7 +2903,7 @@ module SOLIDITY-UNISWAP-GETRESERVES-SUMMARY
         <this-type> TYPE </this-type>
         <contract-id> TYPE </contract-id>
         <current-function> getReserves </current-function>
-        <env> ENV=> ENV [ reserves <- var(1, uint112 []) ] </env>
+        <env> ENV=> ENV [ reserves <- var(size(S), uint112 []) ] </env>
         <store> S => S ListItem(
                               ListItem({Storage[reserve0] orDefault 0p112}:>MInt{112})
                               ListItem({Storage[reserve1] orDefault 0p112}:>MInt{112})

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2891,6 +2891,29 @@ endmodule
 ```
 
 ```k
+module SOLIDITY-UNISWAP-GETRESERVES-SUMMARY 
+  imports SOLIDITY-CONFIGURATION
+  imports SOLIDITY-EXPRESSION
+  imports SOLIDITY-UNISWAP-TOKENS
+
+  rule <k> reserves = new uint112 [ ] ( 3 , .TypedVals ) ;  reserves [ 0 ] = reserve0 ;  reserves [ 1 ] = reserve1 ;  reserves [ 2 ] = blockTimestampLast ;  .Statements ~> return reserves ; ~> .K => return v ( ListItem({Storage[reserve0] orDefault 0p112}:>MInt{112}) ListItem({Storage[reserve1] orDefault 0p112}:>MInt{112}) ListItem(roundMInt({Storage[blockTimestampLast] orDefault 0p32}:>MInt{32}):MInt{112}) , uint112 [ ] ) ; ~> .K</k> 
+        <summarize> true </summarize>
+        <this> THIS </this>
+        <contract-address> THIS </contract-address>
+        <this-type> TYPE </this-type>
+        <contract-id> TYPE </contract-id>
+        <env> ENV=> ENV [ reserves <- var(1, uint112 []) ] </env>
+        <store> S => S ListItem(
+                              ListItem({Storage[reserve0] orDefault 0p112}:>MInt{112})
+                              ListItem({Storage[reserve1] orDefault 0p112}:>MInt{112})
+                              ListItem(roundMInt({Storage[blockTimestampLast] orDefault 0p32}:>MInt{32}):MInt{112})
+                            )
+        </store>
+        <contract-storage> Storage </contract-storage> [priority(40)]
+endmodule
+```
+
+```k
 module SOLIDITY-UNISWAP-SUMMARIES
   imports SOLIDITY-UNISWAP-INIT-SUMMARY
   imports SOLIDITY-UNISWAP-SORTTOKENS-SUMMARY
@@ -2899,6 +2922,7 @@ module SOLIDITY-UNISWAP-SUMMARIES
   imports SOLIDITY-UNISWAP-PAIRFOR-SUMMARY
   imports SOLIDITY-UNISWAP-FIDUPDATE-4-SUMMARY
   imports SOLIDITY-UNISWAP-FIDUPDATE-3-SUMMARY
+  imports SOLIDITY-UNISWAP-GETRESERVES-SUMMARY
 
 endmodule
 ```


### PR DESCRIPTION
This PR adds the summarized rules regarding the body of program execution. The rule presented in this PR summarizes the body of `getReserved` function.

By summarizing this function, we save 826 steps.
(Without it, the program took 27872 steps, and after implementing it, the program took 27062 steps)