### PR TITLE
mathSqrt summary

### DIFF
--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3280,6 +3280,13 @@ module SOLIDITY-MATHSQRT-SUMMARY
        <call-stack>... .List => ListItem(frame(K, E, FUNC)) </call-stack>
     requires V >uMInt 3p256 [priority(40)]
 
+  // While loop rewrite and condition evaluation
+  rule <k> while (( x < z ) #as Cond) Body:Statement Ss:Statements => if (v(Vx <uMInt Vz, bool)) {Body while(Cond) Body} else {.Statements} ~> Ss ...</k>
+       <summarize> true </summarize>
+       <env>... (x |-> var(Ix, uint256)) (z |-> var(Iz, uint256)) ...</env>
+       <store> _ [ Ix <- Vx:MInt{256} ] [ Iz <- Vz:MInt{256} ] </store>
+       <current-function> mathSqrt </current-function> [priority(40)]
+
   // y <= 3 && y != 0
   rule <k> mathSqrt:Id ( v(V:MInt{256}, uint256), .TypedVals ) => v (1p256, uint256) ...</k>
        <summarize> true </summarize>

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3301,6 +3301,21 @@ module SOLIDITY-MATHSQRT-SUMMARY
        </store>
        <current-function> mathSqrt </current-function> [priority(40)]
 
+  // Skip environment updates when not needed.
+  // These occur due to the multiple block statements, introduced by the if
+  // statement that the while rewrites to.
+  rule <k> restoreEnv( _:Map ) ~> .Statements ~> restoreEnv( E:Map ) => restoreEnv(E) ...</k>
+       <summarize> true </summarize>
+       <current-function> mathSqrt </current-function> [priority(40)]
+
+  // End of function: final environment restoration to return to caller
+  rule <k> restoreEnv ( _:Map (z |-> var(Iz, uint256)) ) ~> .Statements ~> return z ; ~> .K => v (Vz, uint256) ~> K </k>
+       <summarize> true </summarize>
+       <env> _ => E </env>
+       <store> _ [ Iz <- Vz ] </store>
+       <current-function> mathSqrt => FUNC </current-function>
+       <call-stack>... ListItem(frame(K, E, FUNC)) => .List </call-stack> [priority(40)]
+
   // y <= 3 && y != 0
   rule <k> mathSqrt:Id ( v(V:MInt{256}, uint256), .TypedVals ) => v (1p256, uint256) ...</k>
        <summarize> true </summarize>

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3287,6 +3287,20 @@ module SOLIDITY-MATHSQRT-SUMMARY
        <store> _ [ Ix <- Vx:MInt{256} ] [ Iz <- Vz:MInt{256} ] </store>
        <current-function> mathSqrt </current-function> [priority(40)]
 
+  // While condition evaluated to true until next while statement
+  rule <k> if ( v ( true , bool ) ) { { z = x ;  x = ( y / x + x ) / 2 ;  .Statements }  Ss:Statements } else { .Statements } => Ss ~> restoreEnv(E) ...</k>
+       <summarize> true </summarize>
+       <env>
+         ( _ (x |-> var(Ix, uint256))
+             (y |-> var(Iy, uint256))
+             (z |-> var(Iz, uint256)) ) #as E
+       </env>
+       <store>
+          ( _ [ Ix <- Vx:MInt{256} ] [ Iy <- Vy:MInt{256} ] ) #as STORE =>
+          STORE [ Iz <- Vx ] [ Ix <- ((Vy /uMInt Vx) +MInt Vx) /uMInt 2p256 ]
+       </store>
+       <current-function> mathSqrt </current-function> [priority(40)]
+
   // y <= 3 && y != 0
   rule <k> mathSqrt:Id ( v(V:MInt{256}, uint256), .TypedVals ) => v (1p256, uint256) ...</k>
        <summarize> true </summarize>

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3254,6 +3254,40 @@ endmodule
 ```
 
 ```k
+module SOLIDITY-MATHSQRT-SUMMARY
+  imports SOLIDITY-CONFIGURATION
+  imports SOLIDITY-UNISWAP-TOKENS
+  imports SOLIDITY-EXPRESSION
+  imports SOLIDITY-STATEMENT
+
+  rule <k> mathSqrt:Id ( v(V:MInt{256}, uint256), .TypedVals ) ~> K => Ss ~> restoreEnv( (y |-> var(size(STORE), uint256)) (z |-> var(size(STORE) +Int 1, uint256)) ) ~> .Statements ~> return z ; ~> .K </k>
+       <summarize> true </summarize>
+       <this-type> TYPE </this-type>
+       <contract-id> TYPE </contract-id>
+       <contract-fn-id> mathSqrt </contract-fn-id>
+       <contract-fn-body> if ( y > 3 ) { z = y ;  uint256 x = y / 2 + 1 ; Ss:Statements } else if ( y != 0 ) { _:Statements }  .Statements </contract-fn-body>
+       <env> E => (y |-> var(size(STORE), uint256))
+                  (z |-> var(size(STORE) +Int 1, uint256))
+                  (x |-> var(size(STORE) +Int 2, uint256))
+       </env>
+       <store> STORE =>
+               STORE ListItem(V) // y
+                     ListItem(V) // z
+                     ListItem((V /uMInt 2p256) +MInt 1p256) // x
+        </store>
+       <current-function> FUNC => mathSqrt </current-function>
+       <call-stack>... .List => ListItem(frame(K, E, FUNC)) </call-stack>
+    requires V >uMInt 3p256 [priority(40)]
+
+  rule <k> mathSqrt:Id ( v(V:MInt{256}, uint256), .TypedVals ) => v (1p256, uint256) ...</k>
+       <summarize> true </summarize>
+       <store> STORE => STORE ListItem(V) ListItem(1p256) </store>
+    requires V <=uMInt 3p256 andBool V =/=MInt 0p256 [priority(40)]
+
+endmodule
+```
+
+```k
 module SOLIDITY-UNISWAP-SUMMARIES
   imports SOLIDITY-UNISWAP-INIT-SUMMARY
   imports SOLIDITY-UNISWAP-SORTTOKENS-SUMMARY
@@ -3266,6 +3300,7 @@ module SOLIDITY-UNISWAP-SUMMARIES
   imports SOLIDITY-UNISWAP-FIDUPDATE-3-SUMMARY
   imports SOLIDITY-UNISWAP-GETRESERVES-SUMMARY
   imports SOLIDITY-UNISWAP-SETUP-SUMMARY
+  imports SOLIDITY-MATHSQRT-SUMMARY
 
 endmodule
 ```

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3260,6 +3260,7 @@ module SOLIDITY-MATHSQRT-SUMMARY
   imports SOLIDITY-EXPRESSION
   imports SOLIDITY-STATEMENT
 
+  // y > 3. Start to while loop
   rule <k> mathSqrt:Id ( v(V:MInt{256}, uint256), .TypedVals ) ~> K => Ss ~> restoreEnv( (y |-> var(size(STORE), uint256)) (z |-> var(size(STORE) +Int 1, uint256)) ) ~> .Statements ~> return z ; ~> .K </k>
        <summarize> true </summarize>
        <this-type> TYPE </this-type>
@@ -3279,6 +3280,7 @@ module SOLIDITY-MATHSQRT-SUMMARY
        <call-stack>... .List => ListItem(frame(K, E, FUNC)) </call-stack>
     requires V >uMInt 3p256 [priority(40)]
 
+  // y <= 3 && y != 0
   rule <k> mathSqrt:Id ( v(V:MInt{256}, uint256), .TypedVals ) => v (1p256, uint256) ...</k>
        <summarize> true </summarize>
        <store> STORE => STORE ListItem(V) ListItem(1p256) </store>


### PR DESCRIPTION
This PR introduces summarized rules for the `mathSqrt` function.

These rules are saving 818 steps.

I would like your opinion specifically on this rule [here](https://github.com/Pi-Squared-Inc/solidity-demo-semantics/blob/a6f66dfaa216e7101295a9e28610f425e3d8bf95/src/uniswap-summaries.md?plain=1#L3304):
```
  // Skip environment updates when not needed.
  // These occur due to the multiple block statements, introduced by the if
  // statement that the while rewrites to.
  rule <k> restoreEnv( _:Map ) ~> .Statements ~> restoreEnv( E:Map ) => restoreEnv(E) ...</k>
       <summarize> true </summarize>
       <current-function> mathSqrt </current-function> [priority(40)]
```

Due to the while statement rewriting to an if statement, as the function is executed, there are a lot of block statements that eventually lead to a sequence of
```
restoreEnv(E) ~> .Statements ~> restoreEnv(E) ~> .Statements ~> ...
```
I added this rule to skip the unneeded updates. Due to the number of while loop body executions being input dependent, I cannot specify the exact number that this is repeated, so this is a step per loop iteration.

My question is: is this rule OK to include in a summary, or is it considered a general semantic rule?