### PR TITLE
Introducing `mint` summary from `bind` on `dAIMock`

### DIFF
--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3409,6 +3409,37 @@ endmodule
 ```
 
 ```k
+module SOLIDITY-UNISWAP-MINT-SUMMARY
+  imports SOLIDITY-CONFIGURATION
+  imports SOLIDITY-EXPRESSION
+  imports SOLIDITY-UNISWAP-TOKENS
+
+  rule <k> bind ( _STORE,
+                  ListItem ( usr ) ListItem ( wad ),
+                  ListItem ( address ) ListItem ( uint256 ),
+                  v ( V1:MInt{160} , address ),
+                  v ( V2:MInt{256} , uint256 ),
+                  .TypedVals , .List , .List ) ~> balanceOf [ usr ] = balanceOf [ usr ] + wad ;  totalSupply = totalSupply + wad ;  emit transferEvent ( address ( 0 , .TypedVals ) , usr , wad , .TypedVals ) ;  .Statements ~> return void ; ~> .K => return void ; ~> .K </k>
+        <summarize> true </summarize>
+        <this> THIS </this>
+        <contract-address> THIS </contract-address>
+        <this-type> TYPE </this-type>
+        <contract-id> TYPE </contract-id>
+        <current-function> mint </current-function>
+        <store> S => S ListItem(V1) // usr
+                      ListItem(V2) // wad
+        </store> 
+        <env>
+          ENV => ENV [ usr <- var(size(S)      , address) ]
+                     [ wad <- var(size(S) +Int 1, uint256) ]
+        </env>
+        <contract-storage> Storage => Storage [ totalSupply <- {Storage[totalSupply] orDefault 0p256}:>MInt{256} +MInt V2:MInt{256} ]
+                                              [ balanceOf   <- write({Storage [ balanceOf ] orDefault .Map}:>Value, ListItem(V1), ({read({Storage [ balanceOf ] orDefault .Map}:>Value, ListItem(V1), (mapping ( address account => uint256 )))}:>MInt{256} +MInt V2:MInt{256}), (mapping ( address account => uint256))) ]
+        </contract-storage> [priority(40)]
+endmodule
+```
+
+```k
 module SOLIDITY-UNISWAP-SUMMARIES
   imports SOLIDITY-UNISWAP-INIT-SUMMARY
   imports SOLIDITY-UNISWAP-SORTTOKENS-SUMMARY
@@ -3423,6 +3454,7 @@ module SOLIDITY-UNISWAP-SUMMARIES
   imports SOLIDITY-UNISWAP-GETRESERVES-SUMMARY
   imports SOLIDITY-UNISWAP-SETUP-SUMMARY
   imports SOLIDITY-MATHSQRT-SUMMARY
+  imports SOLIDITY-UNISWAP-MINT-SUMMARY
 
 endmodule
 ```


### PR DESCRIPTION
This PR adds the summarized rules regarding the body of program execution. The rule presented in this PR summarizes the body of `mint` function starting on the `bind` function.

By summarizing the body of this function, we save 300 steps.
(Without it, the program took 20233 steps, and after implementing it, the program took 19933 steps)

Wall Time to execute 1000 `testSwapSingleHopExactAmountIn`:
- On `main` branch: `0.179s`
- On this branch: `0.176s`