### PR TITLE
Introducing `approve` summary from `bind` to `return` on `dAIMock`

### DIFF
--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3430,11 +3430,45 @@ module SOLIDITY-UNISWAP-MINT-SUMMARY
                       ListItem(V2) // wad
         </store> 
         <env>
-          ENV => ENV [ usr <- var(size(S)      , address) ]
+          ENV => ENV [ usr <- var(size(S)       , address) ]
                      [ wad <- var(size(S) +Int 1, uint256) ]
         </env>
         <contract-storage> Storage => Storage [ totalSupply <- {Storage[totalSupply] orDefault 0p256}:>MInt{256} +MInt V2:MInt{256} ]
                                               [ balanceOf   <- write({Storage [ balanceOf ] orDefault .Map}:>Value, ListItem(V1), ({read({Storage [ balanceOf ] orDefault .Map}:>Value, ListItem(V1), (mapping ( address account => uint256 )))}:>MInt{256} +MInt V2:MInt{256}), (mapping ( address account => uint256))) ]
+        </contract-storage> [priority(40)]
+endmodule
+```
+
+```k
+module SOLIDITY-UNISWAP-APPROVE-SUMMARY
+  imports SOLIDITY-CONFIGURATION
+  imports SOLIDITY-EXPRESSION
+  imports SOLIDITY-UNISWAP-TOKENS
+
+  syntax KItem ::= "stopFunction"
+
+  rule <k> bind ( _STORE,
+                  ListItem ( usr ) ListItem ( wad ),
+                  ListItem ( address ) ListItem ( uint256 ) ,
+                  v ( V1:MInt{160} , address ),
+                  v ( V2:MInt{256} , uint256 ),
+                  .TypedVals , ListItem ( bool ) , ListItem ( noId ) ) ~> allowance [ msg . sender ] [ usr ] = wad ;  emit approvalEvent ( msg . sender , usr , wad , .TypedVals ) ;  return true ;  .Statements ~> return void ; ~> .K =>return v ( true , bool ) ; ... </k>
+       <summarize> true </summarize>
+        <this> THIS </this>
+        <contract-address> THIS </contract-address>
+        <this-type> TYPE </this-type>
+        <contract-id> TYPE </contract-id>
+        <current-function> approve </current-function>
+        <store> S => S ListItem(V1) // usr
+                       ListItem(V2) // wad
+        </store>
+        <env>
+          ENV => ENV [ usr <- var(size(S)       , address) ]
+                     [ wad <- var(size(S) +Int 1, uint256) ]
+        </env>
+        <msg-sender> SENDER </msg-sender>
+        <contract-storage>
+          Storage => Storage [ allowance <- write( {Storage [ allowance ] orDefault .Map}:>Value, ListItem(SENDER), (V1 |-> V2:MInt{256}), (mapping ( address daiownr => mapping ( address daispdr => uint256))) )]
         </contract-storage> [priority(40)]
 endmodule
 ```
@@ -3455,6 +3489,7 @@ module SOLIDITY-UNISWAP-SUMMARIES
   imports SOLIDITY-UNISWAP-SETUP-SUMMARY
   imports SOLIDITY-MATHSQRT-SUMMARY
   imports SOLIDITY-UNISWAP-MINT-SUMMARY
+  imports SOLIDITY-UNISWAP-APPROVE-SUMMARY
 
 endmodule
 ```

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3450,7 +3450,7 @@ module SOLIDITY-UNISWAP-APPROVE-SUMMARY
                   ListItem ( address ) ListItem ( uint256 ) ,
                   v ( V1:MInt{160} , address ),
                   v ( V2:MInt{256} , uint256 ),
-                  .TypedVals , ListItem ( bool ) , ListItem ( noId ) ) ~> allowance [ msg . sender ] [ usr ] = wad ;  emit approvalEvent ( msg . sender , usr , wad , .TypedVals ) ;  return true ;  .Statements ~> return void ; ~> .K =>return v ( true , bool ) ; ... </k>
+                  .TypedVals , ListItem ( bool ) , ListItem ( noId ) ) ~> allowance [ msg . sender ] [ usr ] = wad ;  emit approvalEvent ( msg . sender , usr , wad , .TypedVals ) ;  return true ;  .Statements ~> return void ; ~> .K => return v ( true , bool ) ;  ~> .Statements ~> return void ; ... </k>
        <summarize> true </summarize>
         <this> THIS </this>
         <contract-address> THIS </contract-address>
@@ -3466,7 +3466,7 @@ module SOLIDITY-UNISWAP-APPROVE-SUMMARY
         </env>
         <msg-sender> SENDER </msg-sender>
         <contract-storage>
-          Storage => Storage [ allowance <- write( {Storage [ allowance ] orDefault .Map}:>Value, ListItem(SENDER), (V1 |-> V2:MInt{256}), (mapping ( address daiownr => mapping ( address daispdr => uint256))) )]
+          Storage => Storage [ allowance <- write( { Storage [ allowance ] orDefault .Map}:>Value, ListItem(SENDER), write(read({Storage [ allowance ] orDefault .Map}:>Value, ListItem(SENDER), (mapping ( address daiownr => mapping ( address daispdr => uint256)))), ListItem(V1), V2:MInt{256}, (mapping ( address spender => uint256 ))),(mapping ( address daiownr => mapping ( address daispdr => uint256))))]
         </contract-storage> [priority(40)]
 endmodule
 ```

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3445,8 +3445,6 @@ module SOLIDITY-UNISWAP-APPROVE-SUMMARY
   imports SOLIDITY-EXPRESSION
   imports SOLIDITY-UNISWAP-TOKENS
 
-  syntax KItem ::= "stopFunction"
-
   rule <k> bind ( _STORE,
                   ListItem ( usr ) ListItem ( wad ),
                   ListItem ( address ) ListItem ( uint256 ) ,

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3519,6 +3519,7 @@ module SOLIDITY-UNISWAP-APPROVE-SUMMARY
         <this-type> TYPE </this-type>
         <contract-id> TYPE </contract-id>
         <current-function> approve </current-function>
+        <contract-state>  (allowance |-> mapping ( address daiownr => mapping ( address daispdr => uint256 ) )) </contract-state>
         <store> S => S ListItem(V1) // usr
                        ListItem(V2) // wad
         </store>


### PR DESCRIPTION
This PR adds the summarized rules regarding the body of program execution. The rule presented in this PR summarizes the body of `approve` function starting on the `bind` function.

By summarizing the body of this function, we save 308 steps.
(Without it, the program took 19933 steps, and after implementing it, the program took 19625 steps)

Wall Time to execute 1000 `testSwapSingleHopExactAmountIn` summarized:
- On `main` branch: `0.179s`
- On this branch: `0.176s`

Wall Time to execute 1000 `testSwapSingleHopExactAmountIn` without any summarization: `0.263s`