### PR TITLE
Summary for `swapExactTokensForTokens`

### DIFF
--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3010,6 +3010,13 @@ module SOLIDITY-UNISWAP-SWAPEXACTTOKENSFORTOKENS-SUMMARY
        <store> _ [ Ito <- Vto:MInt{160} ] </store>
        <current-function> swapExactTokensForTokens </current-function> [priority(40)]
 
+  // fidSwap return to function return
+  rule <k> void ~> freezerExpressionStatement ( ) ~> .Statements ~> return amounts ; => return v(Va, uint256 [ ]) ; ...</k>
+       <summarize> true </summarize>
+       <env>... (amounts |-> var(Ia, uint256 [ ])) ...</env>
+       <store> _ [ Ia <- Va ] </store>
+       <current-function> swapExactTokensForTokens </current-function> [priority(40)]
+
 endmodule
 ```
 

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2992,6 +2992,14 @@ module SOLIDITY-UNISWAP-SWAPEXACTTOKENSFORTOKENS-SUMMARY
        <current-function> swapExactTokensForTokens </current-function>
     requires {read(V, ListItem(MInt2Unsigned(Int2MInt(size(V))::MInt{256} -MInt 1p256)), uint256 [ ])}:>MInt{256} >=uMInt Vao [priority(40)]
 
+  // uniswapV2LibraryPairFor return to transferFrom call
+  rule <k> v ( Vpair:MInt{160} , address ) ~> freezerCallArgumentListTail ( v ( Vamounts0 , uint256 ) , .TypedVals ) ~> freezerCallArgumentListHead ( msg . sender ) ~> freezerExternalCallArgs ( iERC20 ( path [ 0 ] , .TypedVals ) , transferFrom ) => v ( Vp0 , iERC20 ) . transferFrom ( v ( SENDER , address ) , v ( Vpair , address ) , v ( Vamounts0 , uint256 ) , .TypedVals ) ...</k>
+       <summarize> true </summarize>
+       <env>... (path |-> var ( Ip , address [ ] )) ...</env>
+       <store> _ [ Ip <- ListItem(Vp0:MInt{160}) _ ] </store>
+       <msg-sender> SENDER </msg-sender>
+       <current-function> swapExactTokensForTokens </current-function> [priority(40)]
+
 endmodule
 ```
 

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -3000,6 +3000,16 @@ module SOLIDITY-UNISWAP-SWAPEXACTTOKENSFORTOKENS-SUMMARY
        <msg-sender> SENDER </msg-sender>
        <current-function> swapExactTokensForTokens </current-function> [priority(40)]
 
+  // transferFrom return to fidSwap call
+  rule <k> v ( true , bool ) ~> freezerExpressionStatement ( ) ~> fidSwap ( amounts , path , to , .TypedVals ) ; Ss:Statements => fidSwap ( lv ( Ia , .List , uint256 [ ] ) , lv ( Ip , .List , address [ ] ) , v ( Vto , address ) , .TypedVals ) ~> freezerExpressionStatement ( ) ~> Ss ...</k>
+       <summarize> true </summarize>
+       <env>... (amounts |-> var(Ia, uint256 [ ]))
+                (path |-> var (Ip , address [ ]))
+                (to |-> var(Ito, address))
+       ...</env>
+       <store> _ [ Ito <- Vto:MInt{160} ] </store>
+       <current-function> swapExactTokensForTokens </current-function> [priority(40)]
+
 endmodule
 ```
 

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2978,11 +2978,17 @@ module SOLIDITY-UNISWAP-SWAPEXACTTOKENSFORTOKENS-SUMMARY
        </store>
        <current-function> swapExactTokensForTokens </current-function> [priority(40)]
 
-  // uniswapV2LibraryGetAmountsOut return to requires
-  rule <k> v ( V:List , uint256 [ ] ) ~> freezerAssignment ( amounts ) ~> freezerExpressionStatement ( ) ~> require ( amounts [ amounts . length - 1 ] >= amountOutMin , "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT" , .TypedVals ) ; Ss:Statements => Ss ... </k>
+  // uniswapV2LibraryGetAmountsOut return to uniswapV2LibraryPairFor call
+  rule <k> v ( (ListItem(Va0:MInt{256}) _) #as V:List , uint256 [ ] ) ~> freezerAssignment ( amounts ) ~> freezerExpressionStatement ( ) ~> require ( amounts [ amounts . length - 1 ] >= amountOutMin , "UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT" , .TypedVals ) ; iERC20 ( path [ 0 ] , .TypedVals ) . transferFrom ( msg . sender , uniswapV2LibraryPairFor ( path [ 0 ] , path [ 1 ] , .TypedVals ) , amounts [ 0 ] , .TypedVals ) ;  Ss:Statements => uniswapV2LibraryPairFor ( v ( Vp0 , address ) , v ( Vp1 , address ) , .TypedVals ) ~> freezerCallArgumentListTail ( v ( Va0 , uint256 ) , .TypedVals ) ~> freezerCallArgumentListHead ( msg . sender ) ~> freezerExternalCallArgs ( iERC20 ( path [ 0 ] , .TypedVals ) , transferFrom ) ~> freezerExpressionStatement ( ) ~> Ss ... </k>
        <summarize> true </summarize>
-       <env>... (amountOutMin |-> var(Iao, uint256)) (amounts |-> var(Ia, uint256 [ ])) ...</env>
-       <store> ( _ [ Iao <- Vao:MInt{256} ] ) #as S => S [ Ia <- V ] </store>
+       <env>... (amountOutMin |-> var(Iao, uint256))
+                (amounts |-> var(Ia, uint256 [ ]))
+                (path |-> var ( Ip , address [ ] ))
+       ...</env>
+       <store> ( _ [ Iao <- Vao:MInt{256} ]
+                   [ Ip <- ListItem(Vp0:MInt{160}) ListItem(Vp1:MInt{160}) _ ]
+               ) #as S => S [ Ia <- V ]
+       </store>
        <current-function> swapExactTokensForTokens </current-function>
     requires {read(V, ListItem(MInt2Unsigned(Int2MInt(size({read(V, .List, uint256 [ ])}:>List))::MInt{256} -MInt 1p256)), uint256 [ ])}:>MInt{256} >=uMInt Vao [priority(40)]
 

--- a/src/uniswap-summaries.md
+++ b/src/uniswap-summaries.md
@@ -2990,7 +2990,7 @@ module SOLIDITY-UNISWAP-SWAPEXACTTOKENSFORTOKENS-SUMMARY
                ) #as S => S [ Ia <- V ]
        </store>
        <current-function> swapExactTokensForTokens </current-function>
-    requires {read(V, ListItem(MInt2Unsigned(Int2MInt(size({read(V, .List, uint256 [ ])}:>List))::MInt{256} -MInt 1p256)), uint256 [ ])}:>MInt{256} >=uMInt Vao [priority(40)]
+    requires {read(V, ListItem(MInt2Unsigned(Int2MInt(size(V))::MInt{256} -MInt 1p256)), uint256 [ ])}:>MInt{256} >=uMInt Vao [priority(40)]
 
 endmodule
 ```


### PR DESCRIPTION
This PR adds summarized rules for function `swapExactTokensForTokens` of contract `uniswapV2Router02`.
https://github.com/Pi-Squared-Inc/solidity-demo-semantics/blob/dd6d2d0f2be0564a8d87d871e16717ebcf55d059/test/examples/swaps/UniswapV2SwapRenamed.sol#L113

These rules reduce the steps by 357 (from 15011 to 14654).