### PR TITLE
String encoding for ULM return

### DIFF
--- a/byol_solidity.py
+++ b/byol_solidity.py
@@ -26,6 +26,9 @@ deploy_usdc_tx = {
   'maxPriorityFeePerGas': 1000000000,
 }
 
+# deploy USDC
+print("Deploying USDC...")
+
 tx_hash = w3.eth.send_transaction(deploy_usdc_tx)
 print(tx_hash)
 receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
@@ -44,10 +47,14 @@ mint_usdc_tx = {
   'maxPriorityFeePerGas': 1000000000,
 }
 
+# mint USDC
+print("Minting USDC...")
+
 tx_hash = w3.eth.send_transaction(mint_usdc_tx)
 print(tx_hash)
 receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
 print(receipt)
+print("USDC Address:", usdc_address)
 
 balanceOf_usdc_data = '70a08231000000000000000000000000' + sender.address[2:]
 
@@ -60,6 +67,9 @@ balanceOf_usdc_tx = {
   'maxFeePerGas': 2000000000,
   'maxPriorityFeePerGas': 1000000000,
 }
+
+# balanceOf USDC
+print("balanceOf USDC...")
 
 balance = w3.eth.call(balanceOf_usdc_tx)
 print(balance)
@@ -76,10 +86,16 @@ transfer_usdc_tx = {
   'maxPriorityFeePerGas': 1000000000,
 }
 
+# transfer USDC
+print("transfer USDC...")
+
 tx_hash = w3.eth.send_transaction(transfer_usdc_tx)
 print(tx_hash)
 receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
 print(receipt)
+
+# balanceOf USDC
+print("balanceOf USDC...")
 
 balance = w3.eth.call(balanceOf_usdc_tx)
 print(balance)
@@ -89,3 +105,51 @@ balanceOf_usdc_tx['data'] = balanceOf_usdc_data2
 
 balance = w3.eth.call(balanceOf_usdc_tx)
 print(balance)
+
+# decimals USDC
+decimals_usdc_data = '313ce567'
+decimals_usdc_tx = {
+  'from': sender.address,
+  'data': decimals_usdc_data,
+  'to': usdc_address,
+  'value': 0,
+  'gas': 11000000,
+  'maxFeePerGas': 2000000000,
+  'maxPriorityFeePerGas': 1000000000,
+}
+
+decimals = w3.eth.call(decimals_usdc_tx)
+print("Decimals:", int(decimals.hex(), 16))
+
+# name
+name_usdc_data = '06fdde03'
+name_usdc_tx = {
+  'from': sender.address,
+  'data': name_usdc_data,
+  'to': usdc_address,
+  'value': 0,
+  'gas': 11000000,
+  'maxFeePerGas': 2000000000,
+  'maxPriorityFeePerGas': 1000000000,
+}
+
+name = w3.eth.call(name_usdc_tx)
+name = w3.to_text(name)
+print("Name:", name)
+
+# symbol
+symbol_usdc_data = '95d89b41'
+symbol_usdc_tx = {
+  'from': sender.address,
+  'data': symbol_usdc_data,
+  'to': usdc_address,
+  'value': 0,
+  'gas': 11000000,
+  'maxFeePerGas': 2000000000,
+  'maxPriorityFeePerGas': 1000000000,
+}
+
+symbol = w3.eth.call(symbol_usdc_tx)
+symbol = w3.to_text(symbol)
+print("Symbol:", symbol)
+

--- a/src/solidity.md
+++ b/src/solidity.md
@@ -202,6 +202,9 @@ module SOLIDITY-ULM-SIGNATURE-IMPLEMENTATION
   rule getOutput(<generatedTop>...
                    <k> v(false, bool) ...</k>
                  ...</generatedTop>) => Int2Bytes(32, 0, BE)
+  rule getOutput(<generatedTop>...
+                   <k> S:String ...</k>
+                 ...</generatedTop>) => Int2Bytes(32, 32, BE) +Bytes Int2Bytes(32, lengthString(S), BE) +Bytes padRightBytes(String2Bytes(S), 32, 0) // TODO: All strings in the EVM ABI must be UTF-8 encoded to bytes
 
   // getGasLeft returns the amount of gas left by reading it from the cell <gas>.
   // The semantics currently initialize the gas by reading the appropriate ULM

--- a/src/solidity.md
+++ b/src/solidity.md
@@ -202,6 +202,7 @@ module SOLIDITY-ULM-SIGNATURE-IMPLEMENTATION
   rule getOutput(<generatedTop>...
                    <k> v(false, bool) ...</k>
                  ...</generatedTop>) => Int2Bytes(32, 0, BE)
+  // This rule handles only the case where the return type is exactly one string.
   rule getOutput(<generatedTop>...
                    <k> S:String ...</k>
                  ...</generatedTop>) => Int2Bytes(32, 32, BE) +Bytes Int2Bytes(32, lengthString(S), BE) +Bytes padRightBytes(String2Bytes(S), 32, 0) // TODO: All strings in the EVM ABI must be UTF-8 encoded to bytes

--- a/test/demo-contracts/DAIMock.sol
+++ b/test/demo-contracts/DAIMock.sol
@@ -23,7 +23,7 @@ contract DAIMock {
     }
 
     function name() public returns (string memory) {
-        return "DAI Coin";
+        return "Dai Stablecoin";
     }
 
     function symbol() public returns (string memory) {

--- a/test/demo-contracts/DAIMock.sol
+++ b/test/demo-contracts/DAIMock.sol
@@ -22,6 +22,14 @@ contract DAIMock {
         return dec;
     }
 
+    function name() public returns (string memory) {
+        return "DAI Coin";
+    }
+
+    function symbol() public returns (string memory) {
+        return "DAI";
+    }
+
     function mint(address usr, uint wad) public {
         balanceOf[usr] = balanceOf[usr] + wad;
         totalSupply    = totalSupply + wad;

--- a/test/demo-contracts/USDCMock.sol
+++ b/test/demo-contracts/USDCMock.sol
@@ -21,6 +21,14 @@ contract USDCMock {
         return dec;
     }
 
+    function name() public returns (string memory) {
+        return "USD Coin";
+    }
+
+    function symbol() public returns (string memory) {
+        return "USDC";
+    }
+
     function mint(address account, uint256 value) public {
         require(account != address(0), "USDC: invalid receiver");
         _update(address(0), account, value);

--- a/test/demo-contracts/UniswapV2SwapRenamed.DAI.sol
+++ b/test/demo-contracts/UniswapV2SwapRenamed.DAI.sol
@@ -22,6 +22,14 @@ contract dAIMock {
         return dec;
     }
 
+    function name() public returns (string memory) {
+        return "DAI Coin";
+    }
+
+    function symbol() public returns (string memory) {
+        return "DAI";
+    }
+
     function mint(address usr, uint wad) public {
         balanceOf[usr] = balanceOf[usr] + wad;
         totalSupply    = totalSupply + wad;

--- a/test/demo-contracts/UniswapV2SwapRenamed.DAI.sol
+++ b/test/demo-contracts/UniswapV2SwapRenamed.DAI.sol
@@ -23,7 +23,7 @@ contract dAIMock {
     }
 
     function name() public returns (string memory) {
-        return "DAI Coin";
+        return "Dai Stablecoin";
     }
 
     function symbol() public returns (string memory) {

--- a/test/demo-contracts/UniswapV2SwapRenamed.USDC.sol
+++ b/test/demo-contracts/UniswapV2SwapRenamed.USDC.sol
@@ -21,6 +21,14 @@ contract uSDCMock {
         return dec;
     }
 
+    function name() public returns (string memory) {
+        return "USD Coin";
+    }
+
+    function symbol() public returns (string memory) {
+        return "USDC";
+    }
+
     function mint(address account, uint256 value) public {
         require(account != address(0), "USDC: invalid receiver");
         fidUpdate(address(0), account, value);

--- a/test/demo-contracts/UniswapV2SwapRenamed.WETH.sol
+++ b/test/demo-contracts/UniswapV2SwapRenamed.WETH.sol
@@ -20,6 +20,14 @@ contract wETHMock {
         return dec;
     }
 
+    function name() public returns (string memory) {
+        return "WETH Coin";
+    }
+
+    function symbol() public returns (string memory) {
+        return "WETH";
+    }
+
     function deposit() external payable {
         balanceOf[msg.sender] = balanceOf[msg.sender] + msg.value;
         emit transferEvent(address(0), msg.sender, msg.value);

--- a/test/demo-contracts/UniswapV2SwapRenamed.WETH.sol
+++ b/test/demo-contracts/UniswapV2SwapRenamed.WETH.sol
@@ -21,7 +21,7 @@ contract wETHMock {
     }
 
     function name() public returns (string memory) {
-        return "WETH Coin";
+        return "Wrapped Ether";
     }
 
     function symbol() public returns (string memory) {

--- a/test/demo-contracts/UniswapV2SwapRenamed.WETH.sol
+++ b/test/demo-contracts/UniswapV2SwapRenamed.WETH.sol
@@ -21,7 +21,7 @@ contract wETHMock {
     }
 
     function name() public returns (string memory) {
-        return "Wrapped Ether";
+        return "Wrapped Ethereum";
     }
 
     function symbol() public returns (string memory) {

--- a/test/demo-contracts/WETHMock.sol
+++ b/test/demo-contracts/WETHMock.sol
@@ -21,7 +21,7 @@ contract WETHMock {
     }
 
     function name() public returns (string memory) {
-        return "Wrapped Ether";
+        return "Wrapped Ethereum";
     }
 
     function symbol() public returns (string memory) {

--- a/test/demo-contracts/WETHMock.sol
+++ b/test/demo-contracts/WETHMock.sol
@@ -20,6 +20,14 @@ contract WETHMock {
         return dec;
     }
 
+    function name() public returns (string memory) {
+        return "WETH Coin";
+    }
+
+    function symbol() public returns (string memory) {
+        return "WETH";
+    }
+
     function deposit() external payable {
         balanceOf[msg.sender] = balanceOf[msg.sender] + msg.value;
         emit Transfer(address(0), msg.sender, msg.value);

--- a/test/demo-contracts/WETHMock.sol
+++ b/test/demo-contracts/WETHMock.sol
@@ -21,7 +21,7 @@ contract WETHMock {
     }
 
     function name() public returns (string memory) {
-        return "WETH Coin";
+        return "Wrapped Ether";
     }
 
     function symbol() public returns (string memory) {


### PR DESCRIPTION
This PR implements the `getOutput` function of the ULM interface for `String`, enabling a returned string (at the top of the k cell) to be read.

The Mock contracts are updated each with a `name` and `symbol`  function.

The byol_solidity.py tests those for USDCMock.sol, with the following output:
```
...
Decimals: 18
Name: USD Coin
Symbol:  USDC
```

I am curious as to why there appear to be two spaces in front of the word `USDC` instead of one, especially if this indicates a bug. Please let me know what you think.